### PR TITLE
Choose folder instead of file as backup location

### DIFF
--- a/app/src/main/java/com/stevesoltys/backup/activity/MainActivity.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/MainActivity.java
@@ -5,26 +5,46 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.widget.Button;
 
 import com.stevesoltys.backup.R;
+
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
 
 public class MainActivity extends Activity implements View.OnClickListener {
 
     public static final int OPEN_DOCUMENT_TREE_REQUEST_CODE = 1;
 
-    public static final int LOAD_DOCUMENT_REQUEST_CODE = 2;
+    public static final int OPEN_DOCUMENT_TREE_BACKUP_REQUEST_CODE = 2;
+
+    public static final int LOAD_DOCUMENT_REQUEST_CODE = 3;
 
     private MainActivityController controller;
+    private Button changeLocationButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        controller = new MainActivityController();
+
         findViewById(R.id.create_backup_button).setOnClickListener(this);
         findViewById(R.id.restore_backup_button).setOnClickListener(this);
 
-        controller = new MainActivityController();
+        changeLocationButton = findViewById(R.id.change_backup_location_button);
+        changeLocationButton.setOnClickListener(this);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if (controller.isChangeBackupLocationButtonVisible(this)) {
+            changeLocationButton.setVisibility(VISIBLE);
+        } else {
+            changeLocationButton.setVisibility(GONE);
+        }
     }
 
     @Override
@@ -40,6 +60,10 @@ public class MainActivity extends Activity implements View.OnClickListener {
             case R.id.restore_backup_button:
                 controller.showLoadDocumentActivity(this);
                 break;
+
+            case R.id.change_backup_location_button:
+                controller.onChangeBackupLocationButtonClicked(this);
+                break;
         }
     }
 
@@ -54,7 +78,11 @@ public class MainActivity extends Activity implements View.OnClickListener {
         switch (requestCode) {
 
             case OPEN_DOCUMENT_TREE_REQUEST_CODE:
-                controller.handleChooseFolderResult(result, this);
+                controller.handleChooseFolderResult(result, this, false);
+                break;
+
+            case OPEN_DOCUMENT_TREE_BACKUP_REQUEST_CODE:
+                controller.handleChooseFolderResult(result, this, true);
                 break;
 
             case LOAD_DOCUMENT_REQUEST_CODE:

--- a/app/src/main/java/com/stevesoltys/backup/activity/MainActivity.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/MainActivity.java
@@ -34,7 +34,7 @@ public class MainActivity extends Activity implements View.OnClickListener {
         switch (viewId) {
 
             case R.id.create_backup_button:
-                controller.showChooseFolderActivity(this);
+                controller.onBackupButtonClicked(this);
                 break;
 
             case R.id.restore_backup_button:

--- a/app/src/main/java/com/stevesoltys/backup/activity/MainActivity.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/MainActivity.java
@@ -10,7 +10,7 @@ import com.stevesoltys.backup.R;
 
 public class MainActivity extends Activity implements View.OnClickListener {
 
-    public static final int CREATE_DOCUMENT_REQUEST_CODE = 1;
+    public static final int OPEN_DOCUMENT_TREE_REQUEST_CODE = 1;
 
     public static final int LOAD_DOCUMENT_REQUEST_CODE = 2;
 
@@ -34,7 +34,7 @@ public class MainActivity extends Activity implements View.OnClickListener {
         switch (viewId) {
 
             case R.id.create_backup_button:
-                controller.showCreateDocumentActivity(this);
+                controller.showChooseFolderActivity(this);
                 break;
 
             case R.id.restore_backup_button:
@@ -53,8 +53,8 @@ public class MainActivity extends Activity implements View.OnClickListener {
 
         switch (requestCode) {
 
-            case CREATE_DOCUMENT_REQUEST_CODE:
-                controller.handleCreateDocumentResult(result, this);
+            case OPEN_DOCUMENT_TREE_REQUEST_CODE:
+                controller.handleChooseFolderResult(result, this);
                 break;
 
             case LOAD_DOCUMENT_REQUEST_CODE:

--- a/app/src/main/java/com/stevesoltys/backup/activity/MainActivityController.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/MainActivityController.java
@@ -2,31 +2,47 @@ package com.stevesoltys.backup.activity;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ContentResolver;
 import android.content.Intent;
+import android.net.Uri;
 import android.widget.Toast;
 
 import com.stevesoltys.backup.activity.backup.CreateBackupActivity;
 import com.stevesoltys.backup.activity.restore.RestoreBackupActivity;
 
-import static android.content.Intent.ACTION_CREATE_DOCUMENT;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
 import static android.content.Intent.ACTION_OPEN_DOCUMENT;
+import static android.content.Intent.ACTION_OPEN_DOCUMENT_TREE;
 import static android.content.Intent.CATEGORY_OPENABLE;
+import static android.content.Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION;
+import static android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION;
+import static android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+import static android.provider.DocumentsContract.buildDocumentUriUsingTree;
+import static android.provider.DocumentsContract.createDocument;
+import static android.provider.DocumentsContract.getTreeDocumentId;
+import static com.stevesoltys.backup.activity.MainActivity.OPEN_DOCUMENT_TREE_REQUEST_CODE;
 
 /**
  * @author Steve Soltys
+ * @author Torsten Grote
  */
 class MainActivityController {
 
     private static final String DOCUMENT_MIME_TYPE = "application/octet-stream";
+    private static final String DOCUMENT_SUFFIX = "yyyy-MM-dd_HH_mm_ss";
 
-    void showCreateDocumentActivity(Activity parent) {
-        Intent createDocumentIntent = new Intent(ACTION_CREATE_DOCUMENT);
-        createDocumentIntent.addCategory(CATEGORY_OPENABLE);
-        createDocumentIntent.setType(DOCUMENT_MIME_TYPE);
+    void showChooseFolderActivity(Activity parent) {
+        Intent createDocumentIntent = new Intent(ACTION_OPEN_DOCUMENT_TREE);
+        createDocumentIntent.addFlags(FLAG_GRANT_PERSISTABLE_URI_PERMISSION |
+                FLAG_GRANT_READ_URI_PERMISSION | FLAG_GRANT_WRITE_URI_PERMISSION);
 
         try {
             Intent documentChooser = Intent.createChooser(createDocumentIntent, "Select the backup location");
-            parent.startActivityForResult(documentChooser, MainActivity.CREATE_DOCUMENT_REQUEST_CODE);
+            parent.startActivityForResult(documentChooser, OPEN_DOCUMENT_TREE_REQUEST_CODE);
 
         } catch (ActivityNotFoundException ex) {
             Toast.makeText(parent, "Please install a file manager.", Toast.LENGTH_SHORT).show();
@@ -47,14 +63,33 @@ class MainActivityController {
         }
     }
 
-    void handleCreateDocumentResult(Intent result, Activity parent) {
+    void handleChooseFolderResult(Intent result, Activity parent) {
 
-        if (result == null) {
+        if (result == null || result.getData() == null) {
+            return;
+        }
+
+        Uri folderUri = result.getData();
+        ContentResolver contentResolver = parent.getContentResolver();
+
+        // persist permission to access backup folder across reboots
+        int takeFlags = result.getFlags() &
+                (FLAG_GRANT_READ_URI_PERMISSION | FLAG_GRANT_WRITE_URI_PERMISSION);
+        contentResolver.takePersistableUriPermission(folderUri, takeFlags);
+
+        // create backup file in folder
+        Uri fileUri;
+        try {
+            fileUri = createBackupFile(contentResolver, folderUri);
+        } catch (IOException e) {
+            // TODO show better error message once more infrastructure is in place
+            Toast.makeText(parent, "Error creating backup file", Toast.LENGTH_SHORT).show();
+            e.printStackTrace();
             return;
         }
 
         Intent intent = new Intent(parent, CreateBackupActivity.class);
-        intent.setData(result.getData());
+        intent.setData(fileUri);
         parent.startActivity(intent);
     }
 
@@ -68,4 +103,18 @@ class MainActivityController {
         intent.setData(result.getData());
         parent.startActivity(intent);
     }
+
+    private Uri createBackupFile(ContentResolver contentResolver, Uri folderUri) throws IOException {
+        Uri documentUri = buildDocumentUriUsingTree(folderUri, getTreeDocumentId(folderUri));
+        Uri fileUri = createDocument(contentResolver, documentUri, DOCUMENT_MIME_TYPE, getBackupFileName());
+        if (fileUri == null) throw new IOException();
+        return fileUri;
+    }
+
+    private String getBackupFileName() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DOCUMENT_SUFFIX, Locale.US);
+        String date = dateFormat.format(new Date());
+        return "backup-" + date;
+    }
+
 }

--- a/app/src/main/java/com/stevesoltys/backup/activity/MainActivityController.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/MainActivityController.java
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.stevesoltys.backup.activity.backup.CreateBackupActivity;
@@ -35,6 +36,8 @@ import static com.stevesoltys.backup.settings.SettingsManager.setBackupFolderUri
  */
 class MainActivityController {
 
+    private static final String TAG = MainActivityController.class.getName();
+
     private static final String DOCUMENT_MIME_TYPE = "application/octet-stream";
     private static final String DOCUMENT_SUFFIX = "yyyy-MM-dd_HH_mm_ss";
 
@@ -48,7 +51,7 @@ class MainActivityController {
                 showCreateBackupActivity(parent, fileUri);
 
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.w(TAG, "Error creating backup file: ", e);
                 showChooseFolderActivity(parent, true);
             }
         }
@@ -117,9 +120,9 @@ class MainActivityController {
             showCreateBackupActivity(parent, fileUri);
 
         } catch (IOException e) {
+            Log.e(TAG, "Error creating backup file: ", e);
             // TODO show better error message once more infrastructure is in place
             Toast.makeText(parent, "Error creating backup file", Toast.LENGTH_SHORT).show();
-            e.printStackTrace();
         }
     }
 

--- a/app/src/main/java/com/stevesoltys/backup/settings/SettingsManager.java
+++ b/app/src/main/java/com/stevesoltys/backup/settings/SettingsManager.java
@@ -1,0 +1,27 @@
+package com.stevesoltys.backup.settings;
+
+import android.annotation.Nullable;
+import android.content.Context;
+import android.net.Uri;
+
+import static android.preference.PreferenceManager.getDefaultSharedPreferences;
+
+public class SettingsManager {
+
+    private static final String PREF_KEY_BACKUP_URI = "backupUri";
+
+    public static void setBackupFolderUri(Context context, Uri uri) {
+        getDefaultSharedPreferences(context)
+                .edit()
+                .putString(PREF_KEY_BACKUP_URI, uri.toString())
+                .apply();
+    }
+
+    @Nullable
+    public static Uri getBackupFolderUri(Context context) {
+        String uriStr = getDefaultSharedPreferences(context).getString(PREF_KEY_BACKUP_URI, null);
+        if (uriStr == null) return null;
+        return Uri.parse(uriStr);
+    }
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,29 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:id="@+id/activity_main"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              android:weightSum="1"
-              tools:context="com.stevesoltys.backup.activity.MainActivity">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.stevesoltys.backup.activity.MainActivity">
 
     <Button
         android:id="@+id/create_backup_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/button_horizontal_margin"
-        android:layout_marginRight="@dimen/button_horizontal_margin"
         android:layout_marginTop="@dimen/button_vertical_margin"
-        android:text="@string/create_backup_button"/>
+        android:layout_marginRight="@dimen/button_horizontal_margin"
+        android:text="@string/create_backup_button" />
 
     <Button
         android:id="@+id/restore_backup_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/button_horizontal_margin"
-        android:layout_marginRight="@dimen/button_horizontal_margin"
         android:layout_marginTop="@dimen/button_vertical_margin"
-        android:text="@string/restore_backup_button"/>
+        android:layout_marginRight="@dimen/button_horizontal_margin"
+        android:text="@string/restore_backup_button" />
+
+    <Button
+        android:id="@+id/change_backup_location_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/button_horizontal_margin"
+        android:layout_marginTop="72dp"
+        android:layout_marginRight="@dimen/button_horizontal_margin"
+        android:text="@string/change_backup_location_button" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <string name="create_backup_button">Create backup</string>
     <string name="restore_backup_button">Restore backup</string>
+    <string name="change_backup_location_button">Change backup location</string>
 
     <string name="backup_success">Backup success</string>
     <string name="backup_failure">Backup failure</string>


### PR DESCRIPTION
This merge request changes how the backup storage is chosen in preparation for automatic background backups. Instead of a single file, the user chooses a folder where all backups will be stored. New backup files will be created on-demand with a timestamp in the filename.

To allow the user to change the backup storage location later on, a new button was added to the main screen as provisional UI.