### PR TITLE
Store backup passphrase insecurely for now

### DIFF
--- a/app/src/main/java/com/stevesoltys/backup/activity/backup/CreateBackupActivity.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/backup/CreateBackupActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
+
 import com.stevesoltys.backup.R;
 import com.stevesoltys.backup.activity.PackageListActivity;
 
@@ -22,7 +23,7 @@ public class CreateBackupActivity extends PackageListActivity implements View.On
         int viewId = view.getId();
 
         if (viewId == R.id.create_confirm_button) {
-            controller.showEnterPasswordAlert(selectedPackageList, contentUri, this);
+            controller.onCreateBackupButtonClicked(selectedPackageList, contentUri, this);
         }
     }
 

--- a/app/src/main/java/com/stevesoltys/backup/settings/SettingsManager.java
+++ b/app/src/main/java/com/stevesoltys/backup/settings/SettingsManager.java
@@ -9,6 +9,7 @@ import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 public class SettingsManager {
 
     private static final String PREF_KEY_BACKUP_URI = "backupUri";
+    private static final String PREF_KEY_BACKUP_PASSWORD = "backupLegacyPassword";
 
     public static void setBackupFolderUri(Context context, Uri uri) {
         getDefaultSharedPreferences(context)
@@ -22,6 +23,22 @@ public class SettingsManager {
         String uriStr = getDefaultSharedPreferences(context).getString(PREF_KEY_BACKUP_URI, null);
         if (uriStr == null) return null;
         return Uri.parse(uriStr);
+    }
+
+    /**
+     * This is insecure and not supposed to be part of a release,
+     * but rather an intermediate step towards a generated passphrase.
+     */
+    public static void setBackupPassword(Context context, String password) {
+        getDefaultSharedPreferences(context)
+                .edit()
+                .putString(PREF_KEY_BACKUP_PASSWORD, password)
+                .apply();
+    }
+
+    @Nullable
+    public static String getBackupPassword(Context context) {
+        return getDefaultSharedPreferences(context).getString(PREF_KEY_BACKUP_PASSWORD, null);
     }
 
 }

--- a/app/src/main/java/com/stevesoltys/backup/transport/component/provider/ContentProviderBackupComponent.java
+++ b/app/src/main/java/com/stevesoltys/backup/transport/component/provider/ContentProviderBackupComponent.java
@@ -23,6 +23,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static android.app.backup.BackupTransport.*;
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Steve Soltys
@@ -245,9 +246,8 @@ public class ContentProviderBackupComponent implements BackupComponent {
             backupState.getOutputStream().write(backupState.getSalt());
             backupState.getOutputStream().closeEntry();
 
-            if (configuration.getPassword() != null && !configuration.getPassword().isEmpty()) {
-                backupState.setSecretKey(KeyGenerator.generate(configuration.getPassword(), backupState.getSalt()));
-            }
+            String password = requireNonNull(configuration.getPassword());
+            backupState.setSecretKey(KeyGenerator.generate(password, backupState.getSalt()));
         }
     }
 


### PR DESCRIPTION
This is being done to implement automatic background updates
and not supposed to be part of a release.

The backup key will later be generated and shown to the user instead of
allowing them to choose their own.