### PR TITLE
Fix backup state handling, end of backup detection

### DIFF
--- a/app/src/main/java/com/stevesoltys/backup/activity/PackageListActivity.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/PackageListActivity.java
@@ -5,8 +5,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
+
 import com.stevesoltys.backup.R;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -17,7 +19,7 @@ public abstract class PackageListActivity extends Activity implements AdapterVie
 
     protected ListView packageListView;
 
-    protected Set<String> selectedPackageList;
+    protected final Set<String> selectedPackageList = new HashSet<>();
 
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         String clickedPackage = (String) packageListView.getItemAtPosition(position);
@@ -34,17 +36,25 @@ public abstract class PackageListActivity extends Activity implements AdapterVie
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 
-        if (item.getItemId() == R.id.action_select_all) {
+        if (item.getItemId() == R.id.action_unselect_all) {
 
             IntStream.range(0, packageListView.getCount())
                     .forEach(position -> {
-                        selectedPackageList.add((String) packageListView.getItemAtPosition(position));
-                        packageListView.setItemChecked(position, true);
+                        selectedPackageList.remove((String) packageListView.getItemAtPosition(position));
+                        packageListView.setItemChecked(position, false);
                     });
 
             return true;
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    public void preSelectAllPackages() {
+        IntStream.range(0, packageListView.getCount())
+                .forEach(position -> {
+                    selectedPackageList.add((String) packageListView.getItemAtPosition(position));
+                    packageListView.setItemChecked(position, true);
+                });
     }
 }

--- a/app/src/main/java/com/stevesoltys/backup/activity/backup/CreateBackupActivity.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/backup/CreateBackupActivity.java
@@ -9,8 +9,6 @@ import android.view.View;
 import com.stevesoltys.backup.R;
 import com.stevesoltys.backup.activity.PackageListActivity;
 
-import java.util.HashSet;
-
 public class CreateBackupActivity extends PackageListActivity implements View.OnClickListener {
 
     private CreateBackupActivityController controller;
@@ -32,7 +30,7 @@ public class CreateBackupActivity extends PackageListActivity implements View.On
         findViewById(R.id.create_confirm_button).setOnClickListener(this);
 
         packageListView = findViewById(R.id.create_package_list);
-        selectedPackageList = new HashSet<>();
+        selectedPackageList.clear();
 
         controller = new CreateBackupActivityController();
         AsyncTask.execute(() -> controller.populatePackageList(packageListView, CreateBackupActivity.this));

--- a/app/src/main/java/com/stevesoltys/backup/activity/backup/CreateBackupActivityController.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/backup/CreateBackupActivityController.java
@@ -64,6 +64,7 @@ class CreateBackupActivityController {
             packageListView.setOnItemClickListener(parent);
             packageListView.setAdapter(new ArrayAdapter<>(parent, R.layout.checked_list_item, eligiblePackageList));
             packageListView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+            parent.preSelectAllPackages();
         });
     }
 

--- a/app/src/main/java/com/stevesoltys/backup/activity/restore/RestoreBackupActivity.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/restore/RestoreBackupActivity.java
@@ -6,10 +6,9 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
+
 import com.stevesoltys.backup.R;
 import com.stevesoltys.backup.activity.PackageListActivity;
-
-import java.util.HashSet;
 
 public class RestoreBackupActivity extends PackageListActivity implements View.OnClickListener {
 
@@ -34,7 +33,8 @@ public class RestoreBackupActivity extends PackageListActivity implements View.O
         findViewById(R.id.restore_confirm_button).setOnClickListener(this);
 
         packageListView = findViewById(R.id.restore_package_list);
-        selectedPackageList = new HashSet<>();
+        selectedPackageList.clear();
+
         contentUri = getIntent().getData();
 
         controller = new RestoreBackupActivityController();

--- a/app/src/main/java/com/stevesoltys/backup/activity/restore/RestoreBackupActivityController.java
+++ b/app/src/main/java/com/stevesoltys/backup/activity/restore/RestoreBackupActivityController.java
@@ -69,6 +69,7 @@ class RestoreBackupActivityController {
             packageListView.setOnItemClickListener(parent);
             packageListView.setAdapter(new ArrayAdapter<>(parent, R.layout.checked_list_item, eligiblePackageList));
             packageListView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+            parent.preSelectAllPackages();
         });
     }
 

--- a/app/src/main/java/com/stevesoltys/backup/service/backup/BackupJobService.java
+++ b/app/src/main/java/com/stevesoltys/backup/service/backup/BackupJobService.java
@@ -9,12 +9,10 @@ import android.os.RemoteException;
 import android.util.Log;
 
 import com.stevesoltys.backup.service.PackageService;
-import com.stevesoltys.backup.transport.ConfigurableBackupTransport;
 import com.stevesoltys.backup.transport.ConfigurableBackupTransportService;
 
 import static android.app.backup.BackupManager.FLAG_NON_INCREMENTAL_BACKUP;
 import static android.os.ServiceManager.getService;
-import static com.stevesoltys.backup.transport.ConfigurableBackupTransportService.getBackupTransport;
 
 public class BackupJobService extends JobService {
 
@@ -34,8 +32,6 @@ public class BackupJobService extends JobService {
         try {
             String[] packages = packageService.getEligiblePackages();
             // TODO use an observer to know when backups fail
-            ConfigurableBackupTransport backupTransport = getBackupTransport(getApplication());
-            backupTransport.prepareBackup(packages.length);
             int result = backupManager.requestBackup(packages, null, null, FLAG_NON_INCREMENTAL_BACKUP);
             if (result == BackupManager.SUCCESS) {
                 Log.i(TAG, "Backup succeeded ");

--- a/app/src/main/java/com/stevesoltys/backup/service/backup/BackupObserver.java
+++ b/app/src/main/java/com/stevesoltys/backup/service/backup/BackupObserver.java
@@ -12,6 +12,8 @@ import com.stevesoltys.backup.session.backup.BackupResult;
 import com.stevesoltys.backup.session.backup.BackupSession;
 import com.stevesoltys.backup.session.backup.BackupSessionObserver;
 
+import static com.stevesoltys.backup.transport.ConfigurableBackupTransportService.getBackupTransport;
+
 /**
  * @author Steve Soltys
  */
@@ -59,6 +61,9 @@ class BackupObserver implements BackupSessionObserver {
 
     @Override
     public void backupSessionCompleted(BackupSession backupSession, BackupResult backupResult) {
+
+        if (backupResult == BackupResult.SUCCESS) getBackupTransport(context).backupFinished();
+
         context.runOnUiThread(() -> {
             if (backupResult == BackupResult.SUCCESS) {
                 Toast.makeText(context, R.string.backup_success, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/stevesoltys/backup/service/backup/BackupService.java
+++ b/app/src/main/java/com/stevesoltys/backup/service/backup/BackupService.java
@@ -30,6 +30,8 @@ public class BackupService {
         try {
             selectedPackages.add("@pm@");
 
+            Log.i(TAG, "Backing up " + selectedPackages.size() + " packages...");
+
             PopupWindow popupWindow = PopupWindowUtil.showLoadingPopupWindow(parent);
             BackupObserver backupObserver = new BackupObserver(parent, popupWindow);
             ConfigurableBackupTransport backupTransport = getBackupTransport(parent.getApplication());

--- a/app/src/main/java/com/stevesoltys/backup/service/backup/BackupService.java
+++ b/app/src/main/java/com/stevesoltys/backup/service/backup/BackupService.java
@@ -11,11 +11,8 @@ import com.stevesoltys.backup.activity.PopupWindowUtil;
 import com.stevesoltys.backup.activity.backup.BackupPopupWindowListener;
 import com.stevesoltys.backup.service.TransportService;
 import com.stevesoltys.backup.session.backup.BackupSession;
-import com.stevesoltys.backup.transport.ConfigurableBackupTransport;
 
 import java.util.Set;
-
-import static com.stevesoltys.backup.transport.ConfigurableBackupTransportService.getBackupTransport;
 
 /**
  * @author Steve Soltys
@@ -34,8 +31,6 @@ public class BackupService {
 
             PopupWindow popupWindow = PopupWindowUtil.showLoadingPopupWindow(parent);
             BackupObserver backupObserver = new BackupObserver(parent, popupWindow);
-            ConfigurableBackupTransport backupTransport = getBackupTransport(parent.getApplication());
-            backupTransport.prepareBackup(selectedPackages.size());
             BackupSession backupSession = transportService.backup(backupObserver, selectedPackages);
 
             View popupWindowButton = popupWindow.getContentView().findViewById(R.id.popup_cancel_button);

--- a/app/src/main/java/com/stevesoltys/backup/session/backup/BackupMonitor.java
+++ b/app/src/main/java/com/stevesoltys/backup/session/backup/BackupMonitor.java
@@ -1,0 +1,20 @@
+package com.stevesoltys.backup.session.backup;
+
+import android.app.backup.IBackupManagerMonitor;
+import android.os.Bundle;
+import android.util.Log;
+
+import static android.app.backup.BackupManagerMonitor.EXTRA_LOG_EVENT_CATEGORY;
+import static android.app.backup.BackupManagerMonitor.EXTRA_LOG_EVENT_ID;
+import static android.app.backup.BackupManagerMonitor.EXTRA_LOG_EVENT_PACKAGE_NAME;
+
+class BackupMonitor extends IBackupManagerMonitor.Stub {
+
+    @Override
+    public void onEvent(Bundle bundle) {
+        Log.d("BackupMonitor", "ID: " + bundle.getInt(EXTRA_LOG_EVENT_ID));
+        Log.d("BackupMonitor", "CATEGORY: " + bundle.getInt(EXTRA_LOG_EVENT_CATEGORY, -1));
+        Log.d("BackupMonitor", "PACKAGE: " + bundle.getString(EXTRA_LOG_EVENT_PACKAGE_NAME, "?"));
+    }
+
+}

--- a/app/src/main/java/com/stevesoltys/backup/session/backup/BackupSession.java
+++ b/app/src/main/java/com/stevesoltys/backup/session/backup/BackupSession.java
@@ -30,7 +30,7 @@ public class BackupSession extends IBackupObserver.Stub {
 
     public void start() throws RemoteException {
         String [] selectedPackageArray = packages.toArray(new String[0]);
-        backupManager.requestBackup(selectedPackageArray, this, null, FLAG_NON_INCREMENTAL_BACKUP);
+        backupManager.requestBackup(selectedPackageArray, this, new BackupMonitor(), FLAG_NON_INCREMENTAL_BACKUP);
     }
 
     public void stop(BackupResult result) throws RemoteException {

--- a/app/src/main/java/com/stevesoltys/backup/transport/ConfigurableBackupTransport.java
+++ b/app/src/main/java/com/stevesoltys/backup/transport/ConfigurableBackupTransport.java
@@ -14,6 +14,9 @@ import com.stevesoltys.backup.transport.component.RestoreComponent;
 import com.stevesoltys.backup.transport.component.provider.ContentProviderBackupComponent;
 import com.stevesoltys.backup.transport.component.provider.ContentProviderRestoreComponent;
 
+import static android.app.backup.BackupAgent.FLAG_CLIENT_SIDE_ENCRYPTION_ENABLED;
+import static android.os.Build.VERSION.SDK_INT;
+
 /**
  * @author Steve Soltys
  */
@@ -50,6 +53,12 @@ public class ConfigurableBackupTransport extends BackupTransport {
     public String name() {
         // TODO: Make this class non-static in ConfigurableBackupTransportService and use Context and a ComponentName.
         return this.getClass().getName();
+    }
+
+    @Override
+    public int getTransportFlags() {
+        if (SDK_INT >= 28) return FLAG_CLIENT_SIDE_ENCRYPTION_ENABLED;
+        return 0;
     }
 
     @Override

--- a/app/src/main/java/com/stevesoltys/backup/transport/ConfigurableBackupTransport.java
+++ b/app/src/main/java/com/stevesoltys/backup/transport/ConfigurableBackupTransport.java
@@ -36,10 +36,6 @@ public class ConfigurableBackupTransport extends BackupTransport {
         restoreComponent = new ContentProviderRestoreComponent(context);
     }
 
-    public void prepareBackup(int numberOfPackages) {
-        backupComponent.prepareBackup(numberOfPackages);
-    }
-
     public void prepareRestore(String password, Uri fileUri) {
         restoreComponent.prepareRestore(password, fileUri);
     }
@@ -63,20 +59,7 @@ public class ConfigurableBackupTransport extends BackupTransport {
 
     @Override
     public boolean isAppEligibleForBackup(PackageInfo targetPackage, boolean isFullBackup) {
-        // TODO re-include key-value (incremental)
-        // affected apps:
-        // * com.android.documentsui
-        // * android
-        // * com.android.nfc
-        // * com.android.calendar
-        // * com.android.providers.settings
-        // * com.android.cellbroadcastreceiver
-        // * com.android.calllogbackup
-        // * com.android.providers.blockednumber
-        // * com.android.providers.userdictionary
-        if (isFullBackup) return true;
-        Log.i(TAG, "Excluding key-value backup of " + targetPackage.packageName);
-        return false;
+        return true;
     }
 
     @Override
@@ -99,15 +82,17 @@ public class ConfigurableBackupTransport extends BackupTransport {
         return backupComponent.currentDestinationString();
     }
 
+    /* Methods related to Backup */
+
     @Override
     public int performBackup(PackageInfo packageInfo, ParcelFileDescriptor inFd, int flags) {
-        // TODO handle flags
-        return performBackup(packageInfo, inFd);
+        return backupComponent.performIncrementalBackup(packageInfo, inFd, flags);
     }
 
     @Override
     public int performBackup(PackageInfo targetPackage, ParcelFileDescriptor fileDescriptor) {
-        return backupComponent.performIncrementalBackup(targetPackage, fileDescriptor);
+        Log.w(TAG, "Warning: Legacy performBackup() method called.");
+        return performBackup(targetPackage, fileDescriptor, 0);
     }
 
     @Override
@@ -155,6 +140,12 @@ public class ConfigurableBackupTransport extends BackupTransport {
     public int clearBackupData(PackageInfo packageInfo) {
         return backupComponent.clearBackupData(packageInfo);
     }
+
+    public void backupFinished() {
+        backupComponent.backupFinished();
+    }
+
+    /* Methods related to Restore */
 
     @Override
     public long getCurrentRestoreSet() {

--- a/app/src/main/java/com/stevesoltys/backup/transport/component/BackupComponent.java
+++ b/app/src/main/java/com/stevesoltys/backup/transport/component/BackupComponent.java
@@ -8,8 +8,6 @@ import android.os.ParcelFileDescriptor;
  */
 public interface BackupComponent {
 
-    void prepareBackup(int numberOfPackages);
-
     String currentDestinationString();
 
     String dataManagementLabel();
@@ -20,7 +18,7 @@ public interface BackupComponent {
 
     int finishBackup();
 
-    int performIncrementalBackup(PackageInfo targetPackage, ParcelFileDescriptor data);
+    int performIncrementalBackup(PackageInfo targetPackage, ParcelFileDescriptor data, int flags);
 
     int performFullBackup(PackageInfo targetPackage, ParcelFileDescriptor fileDescriptor);
 
@@ -35,4 +33,6 @@ public interface BackupComponent {
     long requestBackupTime();
 
     long requestFullBackupTime();
+
+    void backupFinished();
 }

--- a/app/src/main/java/com/stevesoltys/backup/transport/component/provider/ContentProviderBackupState.java
+++ b/app/src/main/java/com/stevesoltys/backup/transport/component/provider/ContentProviderBackupState.java
@@ -2,11 +2,12 @@ package com.stevesoltys.backup.transport.component.provider;
 
 import android.os.ParcelFileDescriptor;
 
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
 import java.io.InputStream;
 import java.security.SecureRandom;
 import java.util.zip.ZipOutputStream;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
 
 /**
  * @author Steve Soltys
@@ -29,13 +30,11 @@ class ContentProviderBackupState {
 
     private String packageName;
 
-    private int packageIndex;
-
     private byte[] salt;
 
     private SecretKey secretKey;
 
-    public ContentProviderBackupState() {
+    ContentProviderBackupState() {
         salt = new byte[16];
         SECURE_RANDOM.nextBytes(salt);
     }
@@ -88,14 +87,6 @@ class ContentProviderBackupState {
         this.outputStream = outputStream;
     }
 
-    int getPackageIndex() {
-        return packageIndex;
-    }
-
-    void setPackageIndex(int packageIndex) {
-        this.packageIndex = packageIndex;
-    }
-
     String getPackageName() {
         return packageName;
     }
@@ -108,11 +99,11 @@ class ContentProviderBackupState {
         return salt;
     }
 
-    public SecretKey getSecretKey() {
+    SecretKey getSecretKey() {
         return secretKey;
     }
 
-    public void setSecretKey(SecretKey secretKey) {
+    void setSecretKey(SecretKey secretKey) {
         this.secretKey = secretKey;
     }
 }

--- a/app/src/main/res/menu/backup_menu.xml
+++ b/app/src/main/res/menu/backup_menu.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:id="@+id/action_select_all"
-        android:title="@string/select_all"
+    <item android:id="@+id/action_unselect_all"
+        android:title="@string/unselect_all"
         android:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
 
     <string name="popup_cancel">Cancel</string>
 
-    <string name="select_all">Select all</string>
+    <string name="unselect_all">Unselect all</string>
     <string name="loading_backup">Loading backup…</string>
     <string name="loading_packages">Loading packages…</string>
     <string name="initializing">Initializing…</string>


### PR DESCRIPTION
This MR fixes the detection of the end of backup. For the current transport it is important to know when the backup ends, because it resets its state only then and closes the ZIP file. 
The detection was broken, because some packages didn't have data to back up (`LOG_EVENT_ID_NO_DATA_TO_SEND`), so the transport's methods weren't called and the package counter not updated. 
The hacky solution is to use the BackupObserver to call back into the transport at the end of backup.
Ideally, future transports won't need to know when the backup finishes.

Additionally, we let the BackupManager know that we use client-side encryption in case some apps require it.

This MR also includes a commit that pre-selects all packages and gives option to unselect all packages. This is useful for testing, because one usually tests with all packages.