### PR TITLE
Also consider contacts with account 'com.android.contacts' for backup

### DIFF
--- a/contactsbackup/src/main/java/org/calyxos/backup/contacts/VCardExporter.java
+++ b/contactsbackup/src/main/java/org/calyxos/backup/contacts/VCardExporter.java
@@ -45,7 +45,7 @@ class VCardExporter {
     private Collection<String> getLookupKeys() {
         String[] projection = new String[]{LOOKUP_KEY};
         // We can not add IS_PRIMARY here as this gets lost on restored contacts
-        String selection = ACCOUNT_TYPE + " is null";
+        String selection = ACCOUNT_TYPE + " is null OR " + ACCOUNT_TYPE + "='com.android.contacts'";
         Cursor cursor = contentResolver.query(CONTENT_URI, projection, selection, null, null);
         if (cursor == null) {
             Log.e(TAG, "Cursor for LOOKUP_KEY is null");


### PR DESCRIPTION
In our tests with CalyxOS, all local contacts had a `null` account, but for some reason on LineageOS, those contacts have `com.android.contacts`. So we now consider this as well.

Fixes #237