### PR TITLE
SeedVault: Show in launcher, as "Backup"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,7 +73,13 @@
         <activity
             android:name=".settings.SettingsActivity"
             android:permission="com.stevesoltys.seedvault.OPEN_SETTINGS"
-            android:exported="true" />
+            android:exported="true"
+            android:label="@string/backup">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ui.storage.StorageActivity"


### PR DESCRIPTION
* Without this, you have to go to Settings -> System -> Advanced - Backup
* That can be a bit too deep sometimes, and those who don't know about this
  may not find it.
* Let's add a Launcher icon so that this is easier to find.
* We call it Backup because people may not know the same SeedVault and thus
  get confused.
* Those who know the name SeedVault probably already know to look for it in
  Settings.

Change-Id: I0d21ed2a9f77786ffab482924b7c1b2cbbf050a9