### PR TITLE
Remove usages of `jcenter()` Maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,6 @@ buildscript {
 
     repositories {
         mavenCentral()
-        //noinspection JcenterRepositoryObsolete
-        jcenter()
         google()
     }
     dependencies {
@@ -33,8 +31,6 @@ apply from: 'gradle/dependencies.gradle'
 allprojects {
     repositories {
         mavenCentral()
-        //noinspection JcenterRepositoryObsolete
-        jcenter()
         google()
         maven { url 'https://jitpack.io' }
     }

--- a/storage/lib/build.gradle
+++ b/storage/lib/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-kapt'
     id "org.jlleitschuh.gradle.ktlint" version "10.2.0"
-    id 'org.jetbrains.dokka' version '1.4.20'
+    id 'org.jetbrains.dokka' version '1.4.30'
 }
 
 android {


### PR DESCRIPTION
This repository is deprecated and it will be shut down in the future.
See http://developer.android.com/r/tools/jcenter-end-of-service for more information.

Change-Id: I9bc875e0b9380a254d91481860f5efb4281c0840