### PR TITLE
Clean up stuck notifications when service gets killed

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransportService.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransportService.kt
@@ -53,7 +53,7 @@ class ConfigurableBackupTransportService : Service(), KoinComponent {
 
     override fun onDestroy() {
         super.onDestroy()
-        notificationManager.onBackupBackgroundFinished()
+        notificationManager.onServiceDestroyed()
         transport = null
         Log.d(TAG, "Service destroyed.")
     }


### PR DESCRIPTION
Cancel left-over notifications that are still ongoing.

We have seen a race condition where the service was taken down at the same time as `BackupObserver#backupFinished()` was called, early enough to miss the cancel.

This won't bring back the expected finish notification in this case, but at least we don't leave stuck notifications laying around.