### PR TITLE
Allow DAVx5 DocumentsProvider by default

### DIFF
--- a/app/src/debug/res/values/config.xml
+++ b/app/src/debug/res/values/config.xml
@@ -6,5 +6,6 @@
         <item>com.android.externalstorage.documents</item>
         <item>org.nextcloud.documents</item>
         <item>org.nextcloud.beta.documents</item>
+        <item>at.bitfire.davdroid.webdav</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -17,6 +17,7 @@
     <string-array name="storage_authority_whitelist" tools:ignore="InconsistentArrays">
         <item>com.android.externalstorage.documents</item>
         <item>org.nextcloud.documents</item>
+        <item>at.bitfire.davdroid.webdav</item>
     </string-array>
 
     <!--


### PR DESCRIPTION
Works better than the Nextcloud app. This allows more people to test. OEMs as always need to make sure that people can restore with this.