### PR TITLE
Fix finishing RequireProvisioningActivity when provisioning is aborted

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <!-- Remove permission requirements only for debug versions to make development easier -->
+        <activity
+            android:name="com.stevesoltys.seedvault.settings.SettingsActivity"
+            android:exported="true"
+            android:permission=""
+            tools:replace="android:permission" />
+        <activity
+            android:name="com.stevesoltys.seedvault.restore.RestoreActivity"
+            android:exported="true"
+            android:permission=""
+            tools:replace="android:permission" />
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/stevesoltys/seedvault/SecretCodeReceiver.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/SecretCodeReceiver.kt
@@ -13,8 +13,7 @@ private const val RESTORE_SECRET_CODE = "7378673"
 class SecretCodeReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        val host = intent.data.host
-        if (RESTORE_SECRET_CODE != host) return
+        if (intent.data?.host != RESTORE_SECRET_CODE) return
         Log.d(TAG, "Restore secret code received.")
         val i = Intent(context, RestoreActivity::class.java).apply {
             flags = FLAG_ACTIVITY_NEW_TASK

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreActivity.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreActivity.kt
@@ -41,8 +41,11 @@ class RestoreActivity : RequireProvisioningActivity() {
     }
 
     @CallSuper
-    override fun onStart() {
-        super.onStart()
+    override fun onResume() {
+        super.onResume()
+        // Activity results from the parent will get delivered before and might tell us to finish.
+        // Don't start any new activities when that happens.
+        // Note: onStart() can get called *before* results get delivered, so we use onResume() here
         if (isFinishing) return
 
         // check that backup is provisioned

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsActivity.kt
@@ -39,8 +39,11 @@ class SettingsActivity : RequireProvisioningActivity(), OnPreferenceStartFragmen
     }
 
     @CallSuper
-    override fun onStart() {
-        super.onStart()
+    override fun onResume() {
+        super.onResume()
+        // Activity results from the parent will get delivered before and might tell us to finish.
+        // Don't start any new activities when that happens.
+        // Note: onStart() can get called *before* results get delivered, so we use onResume() here
         if (isFinishing) return
 
         // check that backup is provisioned

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/RequireProvisioningActivity.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/RequireProvisioningActivity.kt
@@ -55,16 +55,18 @@ abstract class RequireProvisioningActivity : BackupActivity() {
     }
 
     protected fun showStorageActivity() {
-        val intent = Intent(this, StorageActivity::class.java)
-        intent.putExtra(INTENT_EXTRA_IS_RESTORE, getViewModel().isRestoreOperation)
-        intent.putExtra(INTENT_EXTRA_IS_SETUP_WIZARD, isSetupWizard)
+        val intent = Intent(this, StorageActivity::class.java).apply {
+            putExtra(INTENT_EXTRA_IS_RESTORE, getViewModel().isRestoreOperation)
+            putExtra(INTENT_EXTRA_IS_SETUP_WIZARD, isSetupWizard)
+        }
         requestLocation.launch(intent)
     }
 
     protected fun showRecoveryCodeActivity() {
-        val intent = Intent(this, RecoveryCodeActivity::class.java)
-        intent.putExtra(INTENT_EXTRA_IS_RESTORE, getViewModel().isRestoreOperation)
-        intent.putExtra(INTENT_EXTRA_IS_SETUP_WIZARD, isSetupWizard)
+        val intent = Intent(this, RecoveryCodeActivity::class.java).apply {
+            putExtra(INTENT_EXTRA_IS_RESTORE, getViewModel().isRestoreOperation)
+            putExtra(INTENT_EXTRA_IS_SETUP_WIZARD, isSetupWizard)
+        }
         recoveryCodeRequest.launch(intent)
     }
 


### PR DESCRIPTION
On Android 11 this worked fine, but on Android 12 `onStart()` happens before activity results get delivered. We finish the activity when receiving a cancelled result. However, when `onStart()` gets called *before* we know the result, we relaunch an activity required for provisioning again instead of finishing.

Closes #352