### PR TITLE
Allow secondary user backup to USB

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ It uses the same internal APIs as `adb backup` which is deprecated and thus need
 * `android.permission.FOREGROUND_SERVICE` to do periodic storage backups without interruption.
 * `android.permission.MANAGE_DOCUMENTS` to retrieve the available storage roots (optional) for better UX.
 * `android.permission.USE_BIOMETRIC` to authenticate saving a new recovery code
+* `android.permission.INTERACT_ACROSS_USERS_FULL` to use storage roots in other users (optional).
 
 ## Contributing
 Bug reports and pull requests are welcome on GitHub at https://github.com/seedvault-app/seedvault.

--- a/app/src/androidTest/java/com/stevesoltys/seedvault/PluginTest.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/PluginTest.kt
@@ -74,8 +74,8 @@ class PluginTest : KoinComponent {
     fun testInitializationAndRestoreSets() = runBlocking(Dispatchers.IO) {
         // no backups available initially
         assertEquals(0, storagePlugin.getAvailableBackups()?.toList()?.size)
-        val uri = settingsManager.getStorage()?.getDocumentFile(context)?.uri ?: error("no storage")
-        assertFalse(storagePlugin.hasBackup(uri))
+        val s = settingsManager.getStorage() ?: error("no storage")
+        assertFalse(storagePlugin.hasBackup(s))
 
         // prepare returned tokens requested when initializing device
         every { mockedSettingsManager.getToken() } returnsMany listOf(token, token + 1, token + 1)
@@ -90,7 +90,7 @@ class PluginTest : KoinComponent {
 
         // one backup available now
         assertEquals(1, storagePlugin.getAvailableBackups()?.toList()?.size)
-        assertTrue(storagePlugin.hasBackup(uri))
+        assertTrue(storagePlugin.hasBackup(s))
 
         // initializing again (with another restore set) does add a restore set
         storagePlugin.startNewRestoreSet(token + 1)
@@ -98,7 +98,7 @@ class PluginTest : KoinComponent {
         storagePlugin.getOutputStream(token + 1, FILE_BACKUP_METADATA)
             .writeAndClose(getRandomByteArray())
         assertEquals(2, storagePlugin.getAvailableBackups()?.toList()?.size)
-        assertTrue(storagePlugin.hasBackup(uri))
+        assertTrue(storagePlugin.hasBackup(s))
 
         // initializing again (without new restore set) doesn't change number of restore sets
         storagePlugin.initializeDevice()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,11 @@
         android:name="com.stevesoltys.seedvault.RESTORE_BACKUP"
         android:protectionLevel="system|signature" />
 
+    <!-- This is needed to query content providers in other users -->
+    <uses-permission
+        android:name="android.permission.INTERACT_ACROSS_USERS_FULL"
+        tools:ignore="ProtectedPermissions" />
+
     <application
         android:name=".App"
         android:allowBackup="false"

--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -1,12 +1,16 @@
 package com.stevesoltys.seedvault
 
+import android.Manifest.permission.INTERACT_ACROSS_USERS_FULL
 import android.app.Application
 import android.app.backup.BackupManager.PACKAGE_MANAGER_SENTINEL
 import android.app.backup.IBackupManager
+import android.content.Context
 import android.content.Context.BACKUP_SERVICE
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import android.os.ServiceManager.getService
 import android.os.StrictMode
+import android.os.UserHandle
 import com.stevesoltys.seedvault.crypto.cryptoModule
 import com.stevesoltys.seedvault.header.headerModule
 import com.stevesoltys.seedvault.metadata.MetadataManager
@@ -137,4 +141,9 @@ fun <T> permitDiskReads(func: () -> T): T {
     } else {
         func()
     }
+}
+
+fun Context.getSystemContext(isUsbStorage: () -> Boolean): Context {
+    return if (checkSelfPermission(INTERACT_ACROSS_USERS_FULL) == PERMISSION_GRANTED
+        && isUsbStorage()) createContextAsUser(UserHandle.SYSTEM, 0) else this
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -144,6 +144,7 @@ fun <T> permitDiskReads(func: () -> T): T {
 }
 
 fun Context.getSystemContext(isUsbStorage: () -> Boolean): Context {
-    return if (checkSelfPermission(INTERACT_ACROSS_USERS_FULL) == PERMISSION_GRANTED
-        && isUsbStorage()) createContextAsUser(UserHandle.SYSTEM, 0) else this
+    return if (checkSelfPermission(INTERACT_ACROSS_USERS_FULL) == PERMISSION_GRANTED &&
+        isUsbStorage()
+    ) createContextAsUser(UserHandle.SYSTEM, 0) else this
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/StoragePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/StoragePlugin.kt
@@ -1,8 +1,8 @@
 package com.stevesoltys.seedvault.plugins
 
 import android.app.backup.RestoreSet
-import android.net.Uri
 import androidx.annotation.WorkerThread
+import com.stevesoltys.seedvault.settings.Storage
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
@@ -48,14 +48,12 @@ interface StoragePlugin {
     suspend fun removeData(token: Long, name: String)
 
     /**
-     * Searches if there's really a backup available in the given location.
+     * Searches if there's really a backup available in the given storage location.
      * Returns true if at least one was found and false otherwise.
-     *
-     * FIXME: Passing a Uri is too plugin-specific and should be handled differently
      */
     @WorkerThread
     @Throws(IOException::class)
-    suspend fun hasBackup(uri: Uri): Boolean
+    suspend fun hasBackup(storage: Storage): Boolean
 
     /**
      * Get the set of all backups currently available for restore.

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderStoragePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderStoragePlugin.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
+import com.stevesoltys.seedvault.getSystemContext
 import com.stevesoltys.seedvault.plugins.EncryptedMetadata
 import com.stevesoltys.seedvault.plugins.StoragePlugin
 import java.io.FileNotFoundException
@@ -16,11 +17,15 @@ private val TAG = DocumentsProviderStoragePlugin::class.java.simpleName
 
 @Suppress("BlockingMethodInNonBlockingContext")
 internal class DocumentsProviderStoragePlugin(
-    private val context: Context,
+    private val appContext: Context,
     private val storage: DocumentsStorage,
 ) : StoragePlugin {
 
-    private val packageManager: PackageManager = context.packageManager
+    private val context: Context get() = appContext.getSystemContext {
+        storage.storage?.isUsb == true
+    }
+
+    private val packageManager: PackageManager = appContext.packageManager
 
     @Throws(IOException::class)
     override suspend fun startNewRestoreSet(token: Long) {

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderStoragePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderStoragePlugin.kt
@@ -2,12 +2,12 @@ package com.stevesoltys.seedvault.plugins.saf
 
 import android.content.Context
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import com.stevesoltys.seedvault.getSystemContext
 import com.stevesoltys.seedvault.plugins.EncryptedMetadata
 import com.stevesoltys.seedvault.plugins.StoragePlugin
+import com.stevesoltys.seedvault.settings.Storage
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
@@ -77,10 +77,12 @@ internal class DocumentsProviderStoragePlugin(
     }
 
     @Throws(IOException::class)
-    override suspend fun hasBackup(uri: Uri): Boolean {
-        val parent = DocumentFile.fromTreeUri(context, uri) ?: throw AssertionError()
-        val rootDir = parent.findFileBlocking(context, DIRECTORY_ROOT) ?: return false
-        val backupSets = getBackups(context, rootDir)
+    override suspend fun hasBackup(storage: Storage): Boolean {
+        // potentially get system user context if needed here
+        val c = appContext.getSystemContext { storage.isUsb }
+        val parent = DocumentFile.fromTreeUri(c, storage.uri) ?: throw AssertionError()
+        val rootDir = parent.findFileBlocking(c, DIRECTORY_ROOT) ?: return false
+        val backupSets = getBackups(c, rootDir)
         return backupSets.isNotEmpty()
     }
 

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderStoragePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderStoragePlugin.kt
@@ -21,9 +21,13 @@ internal class DocumentsProviderStoragePlugin(
     private val storage: DocumentsStorage,
 ) : StoragePlugin {
 
-    private val context: Context get() = appContext.getSystemContext {
-        storage.storage?.isUsb == true
-    }
+    /**
+     * Attention: This context might be from a different user. Use with care.
+     */
+    private val context: Context
+        get() = appContext.getSystemContext {
+            storage.storage?.isUsb == true
+        }
 
     private val packageManager: PackageManager = appContext.packageManager
 

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
@@ -45,18 +45,20 @@ internal class DocumentsStorage(
     private val appContext: Context,
     private val settingsManager: SettingsManager,
 ) {
-
-    private val context: Context get() = appContext.getSystemContext {
-        storage?.isUsb ?: false
-    }
-
-    private val contentResolver: ContentResolver get() = context.contentResolver
-
     internal var storage: Storage? = null
         get() {
             if (field == null) field = settingsManager.getStorage()
             return field
         }
+
+    /**
+     * Attention: This context might be from a different user. Use with care.
+     */
+    private val context: Context
+        get() = appContext.getSystemContext {
+            storage?.isUsb == true
+        }
+    private val contentResolver: ContentResolver get() = context.contentResolver
 
     internal var rootBackupDir: DocumentFile? = null
         get() = runBlocking {

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
@@ -2,6 +2,7 @@
 
 package com.stevesoltys.seedvault.plugins.saf
 
+import android.content.ContentResolver
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.database.ContentObserver
@@ -15,6 +16,7 @@ import android.provider.DocumentsContract.getDocumentId
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.documentfile.provider.DocumentFile
+import com.stevesoltys.seedvault.getSystemContext
 import com.stevesoltys.seedvault.settings.SettingsManager
 import com.stevesoltys.seedvault.settings.Storage
 import kotlinx.coroutines.TimeoutCancellationException
@@ -40,11 +42,15 @@ const val MIME_TYPE = "application/octet-stream"
 private val TAG = DocumentsStorage::class.java.simpleName
 
 internal class DocumentsStorage(
-    private val context: Context,
+    private val appContext: Context,
     private val settingsManager: SettingsManager,
 ) {
 
-    private val contentResolver = context.contentResolver
+    private val context: Context get() = appContext.getSystemContext {
+        storage?.isUsb ?: false
+    }
+
+    private val contentResolver: ContentResolver get() = context.contentResolver
 
     internal var storage: Storage? = null
         get() {

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
@@ -5,6 +5,7 @@ import android.hardware.usb.UsbDevice
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.Uri
+import android.os.UserHandle
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import androidx.documentfile.provider.DocumentFile
@@ -121,7 +122,8 @@ class SettingsManager(private val context: Context) {
     @WorkerThread
     fun canDoBackupNow(): Boolean {
         val storage = getStorage() ?: return false
-        return !storage.isUnavailableUsb(context) && !storage.isUnavailableNetwork(context)
+        return !storage.isUnavailableUsb(context.createContextAsUser(UserHandle.SYSTEM, 0))
+            && !storage.isUnavailableNetwork(context)
     }
 
     fun backupApks(): Boolean {

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
@@ -5,11 +5,11 @@ import android.hardware.usb.UsbDevice
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.Uri
-import android.os.UserHandle
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import androidx.documentfile.provider.DocumentFile
 import androidx.preference.PreferenceManager
+import com.stevesoltys.seedvault.getSystemContext
 import com.stevesoltys.seedvault.permitDiskReads
 import com.stevesoltys.seedvault.transport.backup.BackupCoordinator
 import java.util.concurrent.ConcurrentSkipListSet
@@ -122,8 +122,8 @@ class SettingsManager(private val context: Context) {
     @WorkerThread
     fun canDoBackupNow(): Boolean {
         val storage = getStorage() ?: return false
-        return !storage.isUnavailableUsb(context.createContextAsUser(UserHandle.SYSTEM, 0))
-            && !storage.isUnavailableNetwork(context)
+        val systemContext = context.getSystemContext { storage.isUsb }
+        return !storage.isUnavailableUsb(systemContext) && !storage.isUnavailableNetwork(context)
     }
 
     fun backupApks(): Boolean {

--- a/app/src/main/java/com/stevesoltys/seedvault/storage/SeedvaultStoragePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/storage/SeedvaultStoragePlugin.kt
@@ -3,15 +3,20 @@ package com.stevesoltys.seedvault.storage
 import android.content.Context
 import androidx.documentfile.provider.DocumentFile
 import com.stevesoltys.seedvault.crypto.KeyManager
+import com.stevesoltys.seedvault.getSystemContext
 import com.stevesoltys.seedvault.plugins.saf.DocumentsStorage
 import org.calyxos.backup.storage.plugin.saf.SafStoragePlugin
 import javax.crypto.SecretKey
 
 internal class SeedvaultStoragePlugin(
-    context: Context,
+    private val appContext: Context,
     private val storage: DocumentsStorage,
     private val keyManager: KeyManager,
-) : SafStoragePlugin(context) {
+) : SafStoragePlugin(appContext) {
+    override val context: Context
+        get() = appContext.getSystemContext {
+            storage.storage?.isUsb == true
+        }
     override val root: DocumentFile
         get() = storage.rootBackupDir ?: error("No storage set")
 

--- a/app/src/main/java/com/stevesoltys/seedvault/storage/SeedvaultStoragePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/storage/SeedvaultStoragePlugin.kt
@@ -13,6 +13,9 @@ internal class SeedvaultStoragePlugin(
     private val storage: DocumentsStorage,
     private val keyManager: KeyManager,
 ) : SafStoragePlugin(appContext) {
+    /**
+     * Attention: This context might be from a different user. Use with care.
+     */
     override val context: Context
         get() = appContext.getSystemContext {
             storage.storage?.isUsb == true

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/RestoreStorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/RestoreStorageViewModel.kt
@@ -24,14 +24,15 @@ internal class RestoreStorageViewModel(
 
     override fun onLocationSet(uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) {
-            saveStorage(uri)
+            val storage = createStorage(uri)
             val hasBackup = try {
-                storagePlugin.hasBackup(uri)
+                storagePlugin.hasBackup(storage)
             } catch (e: IOException) {
                 Log.e(TAG, "Error reading URI: $uri", e)
                 false
             }
             if (hasBackup) {
+                saveStorage(storage)
                 mLocationChecked.postEvent(LocationResult())
             } else {
                 Log.w(TAG, "Location was rejected: $uri")

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/RestoreStorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/RestoreStorageViewModel.kt
@@ -24,6 +24,7 @@ internal class RestoreStorageViewModel(
 
     override fun onLocationSet(uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) {
+            saveStorage(uri)
             val hasBackup = try {
                 storagePlugin.hasBackup(uri)
             } catch (e: IOException) {
@@ -31,7 +32,6 @@ internal class RestoreStorageViewModel(
                 false
             }
             if (hasBackup) {
-                saveStorage(uri)
                 mLocationChecked.postEvent(LocationResult())
             } else {
                 Log.w(TAG, "Location was rejected: $uri")

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/RestoreStorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/RestoreStorageViewModel.kt
@@ -32,7 +32,6 @@ internal class RestoreStorageViewModel(
             }
             if (hasBackup) {
                 saveStorage(uri)
-
                 mLocationChecked.postEvent(LocationResult())
             } else {
                 Log.w(TAG, "Location was rejected: $uri")

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageViewModel.kt
@@ -98,13 +98,21 @@ internal abstract class StorageViewModel(
      */
     protected fun saveStorage(uri: Uri): Boolean {
         // store backup storage location in settings
+        val storage = createStorage(uri)
+        return saveStorage(storage)
+    }
+
+    protected fun createStorage(uri: Uri): Storage {
         val root = safOption ?: throw IllegalStateException("no storage root")
         val name = if (root.isInternal()) {
             "${root.title} (${app.getString(R.string.settings_backup_location_internal)})"
         } else {
             root.title
         }
-        val storage = Storage(uri, name, root.isUsb, root.requiresNetwork)
+        return Storage(uri, name, root.isUsb, root.requiresNetwork)
+    }
+
+    protected fun saveStorage(storage: Storage): Boolean {
         settingsManager.setStorage(storage)
 
         if (storage.isUsb) {
@@ -117,7 +125,7 @@ internal abstract class StorageViewModel(
         }
         BackupManagerSettings.resetDefaults(app.contentResolver)
 
-        Log.d(TAG, "New storage location saved: $uri")
+        Log.d(TAG, "New storage location saved: ${storage.uri}")
 
         return storage.isUsb
     }

--- a/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/StoragePluginTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/StoragePluginTest.kt
@@ -39,6 +39,7 @@ internal class StoragePluginTest : BackupTest() {
         // get current set dir and for that the current token
         every { storage getProperty "currentToken" } returns token
         every { settingsManager.getToken() } returns token
+        every { storage getProperty "storage" } returns null // just to check if isUsb
         coEvery { storage.getSetDir(token) } returns setDir
         // delete contents of current set dir
         coEvery { setDir.listFilesBlocking(context) } returns listOf(backupFile)

--- a/permissions_com.stevesoltys.seedvault.xml
+++ b/permissions_com.stevesoltys.seedvault.xml
@@ -4,6 +4,7 @@
         <permission name="android.permission.BACKUP"/>
         <permission name="android.permission.MANAGE_USB"/>
         <permission name="android.permission.INSTALL_PACKAGES"/>
+        <permission name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
         <permission name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     </privapp-permissions>

--- a/storage/demo/src/main/java/de/grobox/storagebackuptester/plugin/TestSafStoragePlugin.kt
+++ b/storage/demo/src/main/java/de/grobox/storagebackuptester/plugin/TestSafStoragePlugin.kt
@@ -11,7 +11,7 @@ import javax.crypto.SecretKey
 
 @Suppress("BlockingMethodInNonBlockingContext")
 class TestSafStoragePlugin(
-    private val appContext: Context,
+    appContext: Context,
     private val getLocationUri: () -> Uri?,
 ) : SafStoragePlugin(appContext) {
 

--- a/storage/demo/src/main/java/de/grobox/storagebackuptester/plugin/TestSafStoragePlugin.kt
+++ b/storage/demo/src/main/java/de/grobox/storagebackuptester/plugin/TestSafStoragePlugin.kt
@@ -11,10 +11,11 @@ import javax.crypto.SecretKey
 
 @Suppress("BlockingMethodInNonBlockingContext")
 class TestSafStoragePlugin(
-    private val context: Context,
+    private val appContext: Context,
     private val getLocationUri: () -> Uri?,
-) : SafStoragePlugin(context) {
+) : SafStoragePlugin(appContext) {
 
+    override val context = appContext
     override val root: DocumentFile?
         get() {
             val uri = getLocationUri() ?: return null

--- a/storage/lib/src/main/java/org/calyxos/backup/storage/plugin/saf/SafStoragePlugin.kt
+++ b/storage/lib/src/main/java/org/calyxos/backup/storage/plugin/saf/SafStoragePlugin.kt
@@ -35,12 +35,15 @@ private const val TAG = "SafStoragePlugin"
 public abstract class SafStoragePlugin(
     private val appContext: Context,
 ) : StoragePlugin {
-
-    private val cache = SafCache()
-    // In the case of USB storage, if INTERACT_ACROSS_USERS_FULL is granted, this context will match
-    // the system user's application context. Otherwise, matches appContext.
+    /**
+     * Attention: This context could be unexpected. E.g. the system user's application context,
+     * in the case of USB storage, if INTERACT_ACROSS_USERS_FULL permission is granted.
+     * Use [appContext], if you need the context of the current app and user
+     * and [context] for all file access.
+     */
     protected abstract val context: Context
     protected abstract val root: DocumentFile?
+    private val cache = SafCache()
 
     private val folder: DocumentFile?
         get() {
@@ -48,8 +51,9 @@ public abstract class SafStoragePlugin(
             if (cache.currentFolder != null) return cache.currentFolder
 
             @SuppressLint("HardwareIds")
-            // this is unique to each combination of app-signing key, user, and device
-            // so we don't leak anything by not hashing this and can use it as is
+            // This is unique to each combination of app-signing key, user, and device
+            // so we don't leak anything by not hashing this and can use it as is.
+            // Note: Use [appContext] here to not get the wrong ID for a different user.
             val androidId = Settings.Secure.getString(appContext.contentResolver, ANDROID_ID)
             // the folder name is our user ID
             val folderName = "$androidId.sv"

--- a/storage/lib/src/main/java/org/calyxos/backup/storage/plugin/saf/SafStoragePlugin.kt
+++ b/storage/lib/src/main/java/org/calyxos/backup/storage/plugin/saf/SafStoragePlugin.kt
@@ -28,12 +28,18 @@ internal const val CHUNK_FOLDER_COUNT = 256
 
 private const val TAG = "SafStoragePlugin"
 
+/**
+ * @param appContext application context provided by the storage module
+ */
 @Suppress("BlockingMethodInNonBlockingContext")
 public abstract class SafStoragePlugin(
-    private val context: Context,
+    private val appContext: Context,
 ) : StoragePlugin {
 
     private val cache = SafCache()
+    // In the case of USB storage, if INTERACT_ACROSS_USERS_FULL is granted, this context will match
+    // the system user's application context. Otherwise, matches appContext.
+    protected abstract val context: Context
     protected abstract val root: DocumentFile?
 
     private val folder: DocumentFile?
@@ -44,7 +50,7 @@ public abstract class SafStoragePlugin(
             @SuppressLint("HardwareIds")
             // this is unique to each combination of app-signing key, user, and device
             // so we don't leak anything by not hashing this and can use it as is
-            val androidId = Settings.Secure.getString(context.contentResolver, ANDROID_ID)
+            val androidId = Settings.Secure.getString(appContext.contentResolver, ANDROID_ID)
             // the folder name is our user ID
             val folderName = "$androidId.sv"
             cache.currentFolder = try {
@@ -55,8 +61,6 @@ public abstract class SafStoragePlugin(
             }
             return cache.currentFolder
         }
-
-    private val contentResolver = context.contentResolver
 
     private fun timestampToSnapshot(timestamp: Long): String {
         return "$timestamp.SeedSnap"
@@ -153,7 +157,7 @@ public abstract class SafStoragePlugin(
         val name = timestampToSnapshot(timestamp)
         // TODO should we check if it exists first?
         val snapshotFile = folder.createFileOrThrow(name, MIME_TYPE)
-        return snapshotFile.getOutputStream(contentResolver)
+        return snapshotFile.getOutputStream(context.contentResolver)
     }
 
     /************************* Restore *******************************/
@@ -188,7 +192,7 @@ public abstract class SafStoragePlugin(
         val snapshotFile = cache.snapshotFiles.getOrElse(storedSnapshot) {
             getFolder(storedSnapshot).findFileBlocking(context, timestampToSnapshot(timestamp))
         } ?: throw IOException("Could not get file for snapshot $timestamp")
-        return snapshotFile.getInputStream(contentResolver)
+        return snapshotFile.getInputStream(context.contentResolver)
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
By default, Android exposes USB devices only to the main user.
In order to query, read and write to it, the signature permission INTERACT_ACROSS_USERS_FULL (optional) is granted to create Seedvault's context as the system user.

Change-Id: I0b1b4c8c5aeeb226419ff94e15f631ebe1db66df
Issue: calyxos#437
Issue: https://github.com/seedvault-app/seedvault/issues/77