### PR TITLE
Tell user about non enabled backup

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -50,7 +50,7 @@ open class App : Application() {
         factory<IBackupManager> { IBackupManager.Stub.asInterface(getService(BACKUP_SERVICE)) }
         factory { AppListRetriever(this@App, get(), get(), get()) }
 
-        viewModel { SettingsViewModel(this@App, get(), get(), get(), get(), get(), get()) }
+        viewModel { SettingsViewModel(this@App, get(), get(), get(), get(), get(), get(), get()) }
         viewModel { RecoveryCodeViewModel(this@App, get(), get(), get(), get(), get(), get()) }
         viewModel { BackupStorageViewModel(this@App, get(), get(), get(), get()) }
         viewModel { RestoreStorageViewModel(this@App, get(), get()) }

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.stevesoltys.seedvault.settings
 
 import android.app.Application
+import android.app.backup.IBackupManager
 import android.app.job.JobInfo.NETWORK_TYPE_NONE
 import android.app.job.JobInfo.NETWORK_TYPE_UNMETERED
 import android.content.Intent
@@ -49,6 +50,7 @@ internal class SettingsViewModel(
     private val metadataManager: MetadataManager,
     private val appListRetriever: AppListRetriever,
     private val storageBackup: StorageBackup,
+    private val backupManager: IBackupManager,
 ) : RequireProvisioningViewModel(app, settingsManager, keyManager) {
 
     private val contentResolver = app.contentResolver
@@ -157,6 +159,8 @@ internal class SettingsViewModel(
         // maybe replace the check below with one that checks if our transport service is running
         if (notificationManager.hasActiveBackupNotifications()) {
             Toast.makeText(app, R.string.notification_backup_already_running, LENGTH_LONG).show()
+        } else if (!backupManager.isBackupEnabled) {
+            Toast.makeText(app, R.string.notification_backup_disabled, LENGTH_LONG).show()
         } else viewModelScope.launch(Dispatchers.IO) {
             if (settingsManager.isStorageBackupEnabled()) {
                 val i = Intent(app, StorageBackupService::class.java)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="notification_channel_title">Backup notification</string>
     <string name="notification_title">Backup running</string>
     <string name="notification_backup_already_running">Backup already in progress</string>
+    <string name="notification_backup_disabled">Backup not enabled</string>
 
     <string name="notification_success_title">Backup finished</string>
     <string name="notification_success_text">%1$d of %2$d apps backed up. Tap to learn more.</string>


### PR DESCRIPTION
* Pressing "Backup now" should not just ignore you when it's not actually
  enabled
* Add a toast message telling you it's not enabled

Fixes: #390
Change-Id: I5d698a244652e094b0acfc42cdea017a0af9a20b