### PR TITLE
Mark background backup notification as ongoing

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
@@ -136,6 +136,7 @@ internal class BackupNotificationManager(private val context: Context) {
         val notification = Builder(context, CHANNEL_ID_OBSERVER).apply {
             setSmallIcon(R.drawable.ic_cloud_upload)
             setContentTitle(context.getString(R.string.notification_title))
+            setOngoing(true)
             setShowWhen(false)
             setWhen(System.currentTimeMillis())
             setProgress(0, 0, true)


### PR DESCRIPTION
Background backup notifications are not marked as ongoing. This will make them get propagated to external devices in very quick succession on every update (eg. [by Gadgetbridge](https://codeberg.org/Freeyourgadget/Gadgetbridge/issues/2611))

I can't currently test this (have Seedvault as a system app), but it's a simple enough change - unless there was some specific reason the notification is not marked as ongoing?