### PR TITLE
Exclude storage provider from restore

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkRestore.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkRestore.kt
@@ -41,7 +41,12 @@ internal class ApkRestore(
     @Suppress("BlockingMethodInNonBlockingContext")
     fun restore(backup: RestorableBackup) = flow {
         // filter out packages without APK and get total
-        val packages = backup.packageMetadataMap.filter { it.value.hasApk() }
+        val packages = backup.packageMetadataMap.filter {
+            // We also need to exclude the DocumentsProvider used to retrieve backup data.
+            // Otherwise, it gets killed when we install it, terminating our restoration.
+            val isStorageProvider = it.key == storagePlugin.providerPackageName
+            it.value.hasApk() && !isStorageProvider
+        }
         val total = packages.size
         var progress = 0
 

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkBackupRestoreTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkBackupRestoreTest.kt
@@ -118,6 +118,7 @@ internal class ApkBackupRestoreTest : TransportTest() {
         every { metadataManager.salt } returns salt
         every { crypto.getNameForApk(salt, packageName) } returns name
         every { crypto.getNameForApk(salt, packageName, splitName) } returns suffixName
+        every { storagePlugin.providerPackageName } returns storageProviderPackageName
 
         apkBackup.backupApkIfNecessary(packageInfo, PackageState.APK_AND_DATA, outputStreamGetter)
 

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/TransportTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/TransportTest.kt
@@ -61,6 +61,7 @@ internal abstract class TransportTest {
     protected val salt = metadata.salt
     protected val name = getRandomString(12)
     protected val name2 = getRandomString(23)
+    protected val storageProviderPackageName = getRandomString(23)
 
     init {
         mockkStatic(Log::class)


### PR DESCRIPTION
Excludes the storage provider package from the restoration process. Otherwise, when the storage provider (i.e. DAVx5 or Nextcloud) is installed, it will be terminated, and the restoration process will be interrupted.

Should fix issue #374.