### PR TITLE
Preserve backups when disabling "Backup my apps"

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
@@ -48,7 +48,8 @@ val backupModule = module {
             packageService = get(),
             metadataManager = get(),
             settingsManager = get(),
-            nm = get()
+            nm = get(),
+            backupManager = get(),
         )
     }
 }

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.app.backup.BackupDataInput
 import android.app.backup.BackupDataOutput
 import android.app.backup.BackupTransport.NO_MORE_DATA
 import android.app.backup.BackupTransport.TRANSPORT_OK
+import android.app.backup.IBackupManager
 import android.app.backup.RestoreDescription
 import android.app.backup.RestoreDescription.TYPE_FULL_STREAM
 import android.os.ParcelFileDescriptor
@@ -68,6 +69,12 @@ internal class CoordinatorIntegrationTest : TransportTest() {
     private val fullBackup = FullBackup(backupPlugin, settingsManager, inputFactory, cryptoImpl)
     private val apkBackup = mockk<ApkBackup>()
     private val packageService: PackageService = mockk()
+    private val backupManager: IBackupManager = mockk()
+
+    init {
+        every { backupManager.isBackupEnabled } returns true
+    }
+
     private val backup = BackupCoordinator(
         context,
         backupPlugin,
@@ -78,7 +85,8 @@ internal class CoordinatorIntegrationTest : TransportTest() {
         packageService,
         metadataManager,
         settingsManager,
-        notificationManager
+        notificationManager,
+        backupManager,
     )
 
     private val kvRestore = KVRestore(

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinatorTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinatorTest.kt
@@ -5,6 +5,7 @@ import android.app.backup.BackupTransport.TRANSPORT_NOT_INITIALIZED
 import android.app.backup.BackupTransport.TRANSPORT_OK
 import android.app.backup.BackupTransport.TRANSPORT_PACKAGE_REJECTED
 import android.app.backup.BackupTransport.TRANSPORT_QUOTA_EXCEEDED
+import android.app.backup.IBackupManager
 import android.content.pm.ApplicationInfo.FLAG_STOPPED
 import android.content.pm.PackageInfo
 import android.net.Uri
@@ -48,6 +49,11 @@ internal class BackupCoordinatorTest : BackupTest() {
     private val apkBackup = mockk<ApkBackup>()
     private val packageService: PackageService = mockk()
     private val notificationManager = mockk<BackupNotificationManager>()
+    private val backupManager = mockk<IBackupManager>()
+
+    init {
+        every { backupManager.isBackupEnabled } returns true
+    }
 
     private val backup = BackupCoordinator(
         context,
@@ -59,7 +65,8 @@ internal class BackupCoordinatorTest : BackupTest() {
         packageService,
         metadataManager,
         settingsManager,
-        notificationManager
+        notificationManager,
+        backupManager,
     )
 
     private val metadataOutputStream = mockk<OutputStream>()


### PR DESCRIPTION
Ignore AOSP's attempt to wipe backup data when backups are disabled.

Remaining quirks:
* When backups are re-enabled and another backup is started, the system will call initializeDevice, and Seedvault will generate a new backup salt and start the backup from scratch. This was already the case, and this patch does not change that.

Issue: seedvault-app/seedvault#476
Change-Id: I6ab41a885fcf7c4143814ebe849b8263a4f6e595