### PR TITLE
[DO NOT MERGE] Initial support for backup of D2D-only apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [13-3.2] - 2022-12-29
+* Add expert option to save logs
+* Add more details about branching to README
+* Improvements for debug builds
+* Documentation improvements
+* Better error handling in some cases
+* Some Android 13 upgrades
+
 ## [13-3.1] - 2022-09-01
 * Initial release for Android 13
 * Don't attempt to restore app that is used as a backup location (e.g. Nextcloud),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.stevesoltys.seedvault"
-    android:versionCode="33030020"
+    android:versionCode="33030021"
     android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.stevesoltys.seedvault"
-    android:versionCode="33000301"
-    android:versionName="13-3.1">
+    android:versionCode="33030020"
+    android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.
     The version name is the targeted Android version followed by - and our own version name.

--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import android.os.ServiceManager.getService
 import android.os.StrictMode
+import android.os.SystemProperties
 import android.os.UserHandle
 import com.stevesoltys.seedvault.crypto.cryptoModule
 import com.stevesoltys.seedvault.header.headerModule
@@ -60,6 +61,7 @@ open class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        SystemProperties.set(BACKUP_D2D_PROPERTY, "true")
         startKoin()
         if (isDebugBuild()) {
             StrictMode.setThreadPolicy(
@@ -121,6 +123,8 @@ open class App : Application() {
 const val MAGIC_PACKAGE_MANAGER = PACKAGE_MANAGER_SENTINEL
 const val ANCESTRAL_RECORD_KEY = "@ancestral_record@"
 const val GLOBAL_METADATA_KEY = "@meta@"
+
+const val BACKUP_D2D_PROPERTY = "persist.backup.fake-d2d"
 
 // TODO this doesn't work for LineageOS as they do public debug builds
 fun isDebugBuild() = Build.TYPE == "userdebug"

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransport.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransport.kt
@@ -1,6 +1,7 @@
 package com.stevesoltys.seedvault.transport
 
 import android.app.backup.BackupAgent.FLAG_CLIENT_SIDE_ENCRYPTION_ENABLED
+import android.app.backup.BackupAgent.FLAG_DEVICE_TO_DEVICE_TRANSFER
 import android.app.backup.BackupTransport
 import android.app.backup.RestoreDescription
 import android.app.backup.RestoreSet
@@ -20,7 +21,9 @@ import org.koin.core.component.inject
 // If we ever change this, we should use a ComponentName like the other backup transports.
 val TRANSPORT_ID: String = ConfigurableBackupTransport::class.java.name
 
-const val TRANSPORT_FLAGS = FLAG_CLIENT_SIDE_ENCRYPTION_ENABLED
+// Since there seems to be consensus in the community to pose as device-to-device transport,
+// we are pretending to be one here. This will back up opt-out apps that target at least API 31.
+const val TRANSPORT_FLAGS = FLAG_CLIENT_SIDE_ENCRYPTION_ENABLED or FLAG_DEVICE_TO_DEVICE_TRANSFER
 
 private const val TRANSPORT_DIRECTORY_NAME =
     "com.stevesoltys.seedvault.transport.ConfigurableBackupTransport"

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -143,12 +143,9 @@ internal class BackupCoordinator(
         @Suppress("UNUSED_PARAMETER") isFullBackup: Boolean,
     ): Boolean {
         val packageName = targetPackage.packageName
-        // Check that the app is not blacklisted by the user
-        val enabled = settingsManager.isBackupEnabled(packageName)
-        if (!enabled) Log.w(TAG, "Backup of $packageName disabled by user.")
-        // We need to exclude the DocumentsProvider used to store backup data.
-        // Otherwise, it gets killed when we back it up, terminating our backup.
-        return enabled && targetPackage.packageName != plugin.providerPackageName
+        val shouldInclude = packageService.shouldIncludeAppInBackup(packageName)
+        if (!shouldInclude) Log.i(TAG, "Excluding $packageName from backup.")
+        return shouldInclude
     }
 
     /**

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
@@ -8,7 +8,8 @@ val backupModule = module {
     single {
         PackageService(
             context = androidContext(),
-            backupManager = get()
+            settingsManager = get(),
+            plugin = get()
         )
     }
     single {

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinator.kt
@@ -26,6 +26,14 @@ import com.stevesoltys.seedvault.transport.TRANSPORT_FLAGS
 import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import java.io.IOException
 
+/**
+ * Device name used in AOSP to indicate that a restore set is part of a device-to-device migration.
+ * See getBackupEligibilityRules in frameworks/base/services/backup/java/com/android/server/
+ * backup/restore/ActiveRestoreSession.java. AOSP currently relies on this constant, and it is not
+ * publicly exposed. Framework code indicates they intend to use a flag, instead, in the future.
+ */
+internal const val DEVICE_NAME_FOR_D2D_SET = "D2D"
+
 private data class RestoreCoordinatorState(
     val token: Long,
     val packages: Iterator<PackageInfo>,
@@ -92,7 +100,8 @@ internal class RestoreCoordinator(
      **/
     suspend fun getAvailableRestoreSets(): Array<RestoreSet>? {
         return getAvailableMetadata()?.map { (_, metadata) ->
-            RestoreSet(metadata.deviceName, metadata.deviceName, metadata.token, TRANSPORT_FLAGS)
+            RestoreSet(metadata.deviceName /* name */, DEVICE_NAME_FOR_D2D_SET /* device */,
+                metadata.token, TRANSPORT_FLAGS)
         }?.toTypedArray()
     }
 

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinatorTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinatorTest.kt
@@ -32,8 +32,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.IOException
 import java.io.OutputStream
@@ -181,20 +179,6 @@ internal class BackupCoordinatorTest : BackupTest() {
         assertEquals(quota, backup.getBackupQuota(packageInfo.packageName, isFullBackup))
 
         verify { metadataOutputStream.close() }
-    }
-
-    @Test
-    fun `isAppEligibleForBackup() exempts plugin provider and blacklisted apps`() {
-        every {
-            settingsManager.isBackupEnabled(packageInfo.packageName)
-        } returns true andThen false andThen true
-        every {
-            plugin.providerPackageName
-        } returns packageInfo.packageName andThen "new.package" andThen "new.package"
-
-        assertFalse(backup.isAppEligibleForBackup(packageInfo, true))
-        assertFalse(backup.isAppEligibleForBackup(packageInfo, true))
-        assertTrue(backup.isAppEligibleForBackup(packageInfo, true))
     }
 
     @Test

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinatorTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinatorTest.kt
@@ -87,7 +87,7 @@ internal class RestoreCoordinatorTest : TransportTest() {
 
         val sets = restore.getAvailableRestoreSets() ?: fail()
         assertEquals(2, sets.size)
-        assertEquals(metadata.deviceName, sets[0].device)
+        assertEquals(DEVICE_NAME_FOR_D2D_SET, sets[0].device)
         assertEquals(metadata.deviceName, sets[0].name)
         assertEquals(metadata.token, sets[0].token)
     }

--- a/contactsbackup/src/main/AndroidManifest.xml
+++ b/contactsbackup/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.calyxos.backup.contacts"
-    android:versionCode="33030020"
+    android:versionCode="33030021"
     android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.

--- a/contactsbackup/src/main/AndroidManifest.xml
+++ b/contactsbackup/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.calyxos.backup.contacts"
-    android:versionCode="33000301"
-    android:versionName="13-3.1">
+    android:versionCode="33030020"
+    android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.
     The version name is the targeted Android version followed by - and our own version name.


### PR DESCRIPTION
(It was proposed that a more minimal initial-support PR be opened, vs #473, to make it easier to test functionality on-device.)

Allow backup of apps that would otherwise only support device-to-device migration. This is an initial-support patch to help determine the viability of this approach.

Known issues / TODO:
* System-scheduled backups will not handle D2D-only apps, unless accompanied by a framework change forcing OperationType.MIGRATION. Backups triggered by the connection of a USB device or by Seedvault's StorageBackupService (files) scheduling are not affected, so they *will* back up D2D-only apps as expected; otherwise, the user may need to perform a backup manually via Backup Now.
* Apps with `allowBackup="false"` will appear in Backup Status under "Installed Apps" rather than "Apps that do not allow data backup", and their status will always be blank until they have been backed up. If they are not eligible for migration, it will never change.

Other notes:
* The unit test for excluding the Storage Plugin provider from backups was discussed, deemed unnecessary, and removed.

Co-authored-by: Oliver Scott <olivercscott@gmail.com>
Change-Id: I5a23d68be66f7d8ed755f2bccb9570ab7be49356