### PR TITLE
Update permissions for log feature

### DIFF
--- a/permissions_com.stevesoltys.seedvault.xml
+++ b/permissions_com.stevesoltys.seedvault.xml
@@ -5,6 +5,7 @@
         <permission name="android.permission.MANAGE_USB"/>
         <permission name="android.permission.INSTALL_PACKAGES"/>
         <permission name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
+        <permission name="android.permission.READ_LOGS"/>
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
         <permission name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     </privapp-permissions>


### PR DESCRIPTION
CalyxOS fails to boot with the new log changes, without android.permission.READ_LOGS.