### PR TITLE
[UNTESTED] Support a lack of MANAGE_DOCUMENTS permission

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageActivity.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageActivity.kt
@@ -35,7 +35,9 @@ class StorageActivity : BackupActivity() {
             val authority = uri.authority ?: throw AssertionError("No authority in $uri")
             val storageRoot = StorageRootResolver.getStorageRoots(this, authority).getOrNull(0)
             if (storageRoot == null) {
-                viewModel.onUriPermissionResultReceived(null)
+                viewModel.onSafOptionChosen(
+                    StorageRootResolver.getFakeStorageRootForUri(this, uri))
+                viewModel.onUriPermissionResultReceived(uri)
             } else {
                 viewModel.onSafOptionChosen(storageRoot)
                 viewModel.onUriPermissionResultReceived(uri)

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageRootResolver.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageRootResolver.kt
@@ -3,6 +3,7 @@ package com.stevesoltys.seedvault.ui.storage
 import android.content.Context
 import android.database.Cursor
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.os.UserHandle
 import android.provider.DocumentsContract
 import android.provider.DocumentsContract.Root.COLUMN_AVAILABLE_BYTES
@@ -55,6 +56,21 @@ internal object StorageRootResolver {
             Log.w(TAG, "Failed to load some roots from $authority", e)
         }
         return roots
+    }
+
+    fun getFakeStorageRootForUri(context: Context, uri: Uri): SafOption {
+        return SafOption(
+            authority = AUTHORITY_STORAGE,
+            rootId = "fake",
+            documentId = "fake",
+            // TODO: Use something other than the USB icon?
+            icon = getIcon(context, AUTHORITY_STORAGE, "usb", 0),
+            title = context.getString(R.string.storage_user_selected_location_title),
+            summary = context.getString(R.string.storage_user_selected_location_summary),
+            availableBytes = null,
+            isUsb = false, // TODO: Check this if possible instead of forcing false
+            requiresNetwork = false, // TODO: Check this if possible instead of forcing false
+        )
     }
 
     private fun getStorageRoot(context: Context, authority: String, cursor: Cursor): SafOption? {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
     <string name="storage_fragment_restore_title">Where to find your backups?</string>
     <string name="storage_fragment_warning">People with access to your storage location can learn which apps you use, but do not get access to the apps\' data.</string>
     <string name="storage_fragment_warning_delete">Existing backups in this location will be deleted.</string>
+    <string name="storage_user_selected_location_title">User-chosen location</string>
+    <string name="storage_user_selected_location_summary">Chosen using the folder browser</string>
     <string name="storage_fake_drive_title">USB flash drive</string>
     <string name="storage_fake_drive_summary">Needs to be plugged in</string>
     <string name="storage_available_bytes"><xliff:g example="1 GB" id="size">%1$s</xliff:g> free</string>


### PR DESCRIPTION
The README.md and code comments indicate that it should be possible to use Seedvault without `android.permission.MANAGE_DOCUMENTS`, but that may not be accurate, currently.

When `MANAGE_DOCUMENTS` is not granted, Seedvault prompts to select a storage location using the documents navigator. No matter what location is chosen, Seedvault cannot find backups at that location and experiences errors in logcat as described in seedvault-app/seedvault#247.

With this patch, if resolving the storage's actual root fails, a "fake" storage root is used, as is already done for Nextcloud, Davx5, and USB. (It might be the case that there is no use even *trying* to resolve the storage's actual root, for this situation.)

To test:
1. Include a Seedvault apk that has not been signed with the platform signing key so that it will not be granted the `MANAGE_DOCUMENTS` permission. (One scenario that would cause this would be attempting to include Seedvault in an otherwise-unsupported ROM via a Magisk module.)
2. Try to restore a backup set via `*#*#RESTORE#*#*`.
3. Browse to the parent location of a .SeedVaultAndroidBackup folder.
4. Enter the recovery key when prompted.
5. ...see if it works beyond this point.

(Until now, I have only been able to test up to the point that I am prompted for a recovery key.)