### PR TITLE
gh-actions: Upload debug apks as artifacts

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -33,3 +33,12 @@ jobs:
 
       - name: Build
         run: ./gradlew compileDebugAndroidTestSources check assemble ktlintCheck
+
+      - name: Upload APKs
+        uses: actions/upload-artifact@v3
+        with:
+          name: seedvault-${{ github.sha }}-apks
+          path: |
+            app/build/outputs/apk/debug/app-debug.apk
+            contactsbackup/build/outputs/apk/debug/contactsbackup-debug.apk
+            storage/demo/build/outputs/apk/debug/demo-debug.apk


### PR DESCRIPTION
These APKs are signed with AOSP platform key

They will only be available to logged in users, and you have to navigate to the workflow to find it.

For ROMs signed using those keys (debug builds), this can work as normal.

For ROMs signed with other / private keys, this would still work without `MANAGE_DOCUMENTS`

Related: https://github.com/seedvault-app/seedvault/pull/480