### PR TITLE
[DO NOT MERGE] Fallback APK without D2D changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [13-3.2] - 2022-12-29
+* Add expert option to save logs
+* Add more details about branching to README
+* Improvements for debug builds
+* Documentation improvements
+* Better error handling in some cases
+* Some Android 13 upgrades
+
 ## [13-3.1] - 2022-09-01
 * Initial release for Android 13
 * Don't attempt to restore app that is used as a backup location (e.g. Nextcloud),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.stevesoltys.seedvault"
-    android:versionCode="33000301"
-    android:versionName="13-3.1">
+    android:versionCode="33030020"
+    android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.
     The version name is the targeted Android version followed by - and our own version name.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.stevesoltys.seedvault"
-    android:versionCode="33030020"
+    android:versionCode="33030022"
     android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.

--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import android.os.ServiceManager.getService
 import android.os.StrictMode
+import android.os.SystemProperties
 import android.os.UserHandle
 import com.stevesoltys.seedvault.crypto.cryptoModule
 import com.stevesoltys.seedvault.header.headerModule
@@ -60,6 +61,7 @@ open class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        SystemProperties.set(BACKUP_D2D_PROPERTY, "false")
         startKoin()
         if (isDebugBuild()) {
             StrictMode.setThreadPolicy(
@@ -121,6 +123,8 @@ open class App : Application() {
 const val MAGIC_PACKAGE_MANAGER = PACKAGE_MANAGER_SENTINEL
 const val ANCESTRAL_RECORD_KEY = "@ancestral_record@"
 const val GLOBAL_METADATA_KEY = "@meta@"
+
+const val BACKUP_D2D_PROPERTY = "persist.backup.fake-d2d"
 
 // TODO this doesn't work for LineageOS as they do public debug builds
 fun isDebugBuild() = Build.TYPE == "userdebug"

--- a/contactsbackup/src/main/AndroidManifest.xml
+++ b/contactsbackup/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.calyxos.backup.contacts"
-    android:versionCode="33000301"
-    android:versionName="13-3.1">
+    android:versionCode="33030020"
+    android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.
     The version name is the targeted Android version followed by - and our own version name.

--- a/contactsbackup/src/main/AndroidManifest.xml
+++ b/contactsbackup/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.calyxos.backup.contacts"
-    android:versionCode="33030020"
+    android:versionCode="33030022"
     android:versionName="13-3.2">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.


### PR DESCRIPTION
* Bump version
  * 33030020 -> 13-3.2
  * 33030021 -> d2d test https://github.com/seedvault-app/seedvault/pull/478
  * 33030022 -> This, to go back to normal build after testing
* This is to allow going back to a build without D2D safely,
  because otherwise to uninstall the update to an app you
  have to wipe data.
* Also set the testing property to false
