### PR TITLE
Always start a new RestoreSet when initializing the device

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeViewModel.kt
@@ -107,9 +107,6 @@ internal class RecoveryCodeViewModel(
             storageBackup.deleteAllSnapshots()
             storageBackup.clearCache()
             try {
-                // will also generate a new backup token for the new restore set
-                backupCoordinator.startNewRestoreSet()
-
                 // initialize the new location
                 if (backupManager.isBackupEnabled) backupManager.initializeTransportsForUser(
                     UserHandle.myUserId(),

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/BackupStorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/BackupStorageViewModel.kt
@@ -38,9 +38,6 @@ internal class BackupStorageViewModel(
             storageBackup.deleteAllSnapshots()
             storageBackup.clearCache()
             try {
-                // will also generate a new backup token for the new restore set
-                backupCoordinator.startNewRestoreSet()
-
                 // initialize the new location (if backups are enabled)
                 if (backupManager.isBackupEnabled) backupManager.initializeTransportsForUser(
                     UserHandle.myUserId(),


### PR DESCRIPTION
This avoids deleting the current backup when the user disables backups (or the system decides to do a random re-init).

It is a maybe less hacky alternative to #477.