### PR TITLE
Skip installing APKs if not allowed by policy

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
@@ -1,5 +1,6 @@
 package com.stevesoltys.seedvault.restore.install
 
+import android.os.UserManager
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -7,5 +8,9 @@ val installModule = module {
     factory { ApkInstaller(androidContext()) }
     factory { DeviceInfo(androidContext()) }
     factory { ApkSplitCompatibilityChecker(get()) }
-    factory { ApkRestore(androidContext(), get(), get(), get(), get(), get()) }
+    factory {
+        ApkRestore(androidContext(), get(), get(), get(), get(), get()) {
+            androidContext().getSystemService(UserManager::class.java).isAllowedToInstallApks()
+        }
+    }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallRestriction.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallRestriction.kt
@@ -1,0 +1,17 @@
+package com.stevesoltys.seedvault.restore.install
+
+import android.os.UserManager
+
+internal fun interface InstallRestriction {
+    fun isAllowedToInstallApks(): Boolean
+}
+
+private fun UserManager.isRestricted(restriction: String): Boolean {
+    return userRestrictions.getBoolean(restriction, false)
+}
+
+internal fun UserManager.isAllowedToInstallApks(): Boolean {
+    return isRestricted(UserManager.DISALLOW_INSTALL_APPS) ||
+        isRestricted(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES) ||
+        isRestricted(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES_GLOBALLY)
+}

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkBackupRestoreTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkBackupRestoreTest.kt
@@ -52,6 +52,7 @@ internal class ApkBackupRestoreTest : TransportTest() {
     private val storagePlugin: StoragePlugin<*> = mockk()
     private val splitCompatChecker: ApkSplitCompatibilityChecker = mockk()
     private val apkInstaller: ApkInstaller = mockk()
+    private val installRestriction: InstallRestriction = mockk()
 
     private val apkBackup = ApkBackup(pm, crypto, settingsManager, metadataManager)
     private val apkRestore: ApkRestore = ApkRestore(
@@ -60,7 +61,8 @@ internal class ApkBackupRestoreTest : TransportTest() {
         legacyStoragePlugin = legacyStoragePlugin,
         crypto = crypto,
         splitCompatChecker = splitCompatChecker,
-        apkInstaller = apkInstaller
+        apkInstaller = apkInstaller,
+        installRestriction = installRestriction,
     )
 
     private val signatureBytes = byteArrayOf(0x01, 0x02, 0x03)
@@ -132,6 +134,7 @@ internal class ApkBackupRestoreTest : TransportTest() {
         val apkPath = slot<String>()
         val cacheFiles = slot<List<File>>()
 
+        every { installRestriction.isAllowedToInstallApks() } returns true
         every { strictContext.cacheDir } returns tmpFile
         every { crypto.getNameForApk(salt, packageName, "") } returns name
         coEvery { storagePlugin.getInputStream(token, name) } returns inputStream


### PR DESCRIPTION
Issue: #78 

When APK install is blocked by policy, this should treat it the same as if the APK just wasn't present, and then use the flow we already have for that ("Tap to install"), which is normally used when people turn off "APK Backup"