### PR TITLE
Android 14 - Basic updates, Android.bp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [14-3.3] - 2023-10-06
+* Android 14
+
 ## [13-3.3] - 2023-01-11
 * Mark Nextcloud as "Not recommended"
 * Warn before turning off backups

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ We update it every time Google releases a new Android version, make any changes 
 
 This means that for ROMs using SeedVault it's recommended to use the same branch as your android version
 
-- This current branch `android13` is meant for usage with Android 13
-- This is indicated by the version name starting with `13`, and the version code starting with `33` - the Android 13 API version
+- This current branch `android14` is meant for usage with Android 14
+- This is indicated by the version name starting with `14`, and the version code starting with `34` - the Android 14 API version
 
 For older versions of Android, check out [the branches](https://github.com/seedvault-app/seedvault/branches).
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ It uses the same internal APIs as `adb backup` which is deprecated and thus need
 * `android.permission.MANAGE_EXTERNAL_STORAGE` to backup and restore files from device storage.
 * `android.permission.ACCESS_MEDIA_LOCATION` to backup original media files e.g. without stripped EXIF metadata.
 * `android.permission.FOREGROUND_SERVICE` to do periodic storage backups without interruption.
+* `android.permission.FOREGROUND_SERVICE_DATA_SYNC` to do periodic storage backups without interruption.
 * `android.permission.MANAGE_DOCUMENTS` to retrieve the available storage roots (optional) for better UX.
 * `android.permission.USE_BIOMETRIC` to authenticate saving a new recovery code
 * `android.permission.INTERACT_ACROSS_USERS_FULL` to use storage roots in other users (optional).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,9 @@
         android:name="android.permission.READ_LOGS"
         tools:ignore="ProtectedPermissions" />
 
+    <!-- Used for periodic storage backups -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+
     <!-- Permission used to open settings -->
     <permission
         android:name="com.stevesoltys.seedvault.OPEN_SETTINGS"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.stevesoltys.seedvault"
-    android:versionCode="33030030"
-    android:versionName="13-3.3">
+    android:versionCode="34030030"
+    android:versionName="14-3.3">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.
     The version name is the targeted Android version followed by - and our own version name.

--- a/contactsbackup/src/main/AndroidManifest.xml
+++ b/contactsbackup/src/main/AndroidManifest.xml
@@ -6,8 +6,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.calyxos.backup.contacts"
-    android:versionCode="33030030"
-    android:versionName="13-3.3">
+    android:versionCode="34030030"
+    android:versionName="14-3.3">
     <!--
     The version code is the targeted SDK_VERSION plus 6 digits for our own version code.
     The version name is the targeted Android version followed by - and our own version name.


### PR DESCRIPTION
#564 

SeedVault is built using two build systems
* Android.bp, used for including in AOSP inline
* gradle, mainly used for development, and also to create APKs to include inline

AOSP 14 is here. With this it builds and mostly works in 14. May need more changes. We'll have a temporary mismatch with gradle, but that's ok given this does work.