### PR TITLE
colors: Switch to public APIs for colors

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="accent">@*android:color/accent_device_default_dark</color>
-    <color name="primary">@*android:color/primary_device_default_settings</color>
+    <!-- AOSP colors -->
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#36 -->
+    <color name="accent">@android:color/system_accent1_100</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#22 -->
+    <color name="primary">@android:color/system_neutral1_900</color>
+
+    <!-- Custom colors -->
     <color name="primaryDark">@android:color/black</color>
     <color name="background">@color/primaryDark</color>
     <color name="actionBarPrimary">@color/background</color>
     <color name="statusBarColor">@android:color/transparent</color>
-    <color name="red">@*android:color/error_color_device_default_dark</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,14 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="accent">@*android:color/accent_device_default_light</color>
-    <color name="primary">@*android:color/primary_device_default_settings_light</color>
-    <color name="primaryDark">@*android:color/primary_dark_device_default_settings_light</color>
-    <color name="background">@*android:color/background_device_default_light</color>
-    <color name="actionBarPrimary">@*android:color/primary_device_default_light</color>
-    <color name="statusBarColor">@*android:color/primary_device_default_settings_light
-    </color>
-    <color name="red">@*android:color/error_color_device_default_dark</color>
-    <color name="ic_launcher_background">@*android:color/accent_device_default_light</color>
+    <!-- AOSP colors -->
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#35 -->
+    <color name="accent">@android:color/system_accent1_600</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#23 -->
+    <color name="primary">@android:color/system_neutral1_50</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#27 -->
+    <color name="primaryDark">@color/primary</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#52 -->
+    <color name="background">@android:color/system_neutral1_50</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#21 -->
+    <color name="actionBarPrimary">@color/primary</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#23 -->
+    <color name="statusBarColor">@color/primary</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#69 -->
+    <!-- private resource, access it from colorError attribute instead -->
+    <color name="red">?android:attr/colorError</color>
+    <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/res/res/values/colors_device_defaults.xml#35 -->
+    <color name="ic_launcher_background">@color/accent</color>
+
+    <!-- Custom colors -->
     <color name="divider">#20ffffff</color>
     <color name="green">#558B2F</color>
     <color name="yellow">#F9A825</color>


### PR DESCRIPTION
## Summary

This PR switches color resources to public APIs instead of system ones. This fixes colors on Gradle builds as well as Android Studio can access them as well.

## Related Issues

- https://github.com/seedvault-app/seedvault/issues/549

## Testing

Compile Gradle build, and check all colors look fine.