### PR TITLE
Get app working in Android 14, built via Android.bp

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkInstaller.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkInstaller.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent.FLAG_MUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.Intent.FLAG_RECEIVER_FOREGROUND
 import android.content.IntentFilter
@@ -51,7 +52,11 @@ internal class ApkInstaller(private val context: Context) {
                 cont.resume(onBroadcastReceived(i, packageName, cachedApks, installResult))
             }
         }
-        context.registerReceiver(broadcastReceiver, IntentFilter(BROADCAST_ACTION))
+        context.registerReceiver(
+            broadcastReceiver,
+            IntentFilter(BROADCAST_ACTION),
+            RECEIVER_NOT_EXPORTED,
+        )
         cont.invokeOnCancellation { context.unregisterReceiver(broadcastReceiver) }
 
         install(cachedApks, installerPackageName)


### PR DESCRIPTION
Android.bp builds mostly work on 14, get it across the finish line

restore: Runtime-registered broadcasts receivers must specify export behavior

See: https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported
Change-Id: I6f80a060370a0b202c277924ea8cbf565bc29d6e