### PR TITLE
Support installing via F-Droid Basic

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallIntentCreator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallIntentCreator.kt
@@ -14,6 +14,7 @@ internal class InstallIntentCreator(
     private val installerToPackage = mapOf(
         "org.fdroid.fdroid" to "org.fdroid.fdroid",
         "org.fdroid.fdroid.privileged" to "org.fdroid.fdroid",
+        "org.fdroid.basic" to "org.fdroid.basic",
         "com.aurora.store" to "com.aurora.store",
         "com.aurora.services" to "com.aurora.store",
         "com.android.vending" to "com.android.vending"


### PR DESCRIPTION
If an app being restored was unable to be installed from a backup, e.g. because it was missing, and the app was originally installed with F-Droid Basic, try to install it using F-Droid Basic again, as is done with other listed installers.