### PR TITLE
Fix double start of restore session

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallProgressFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallProgressFragment.kt
@@ -75,7 +75,9 @@ class InstallProgressFragment : Fragment(), InstallItemListener {
 
     private fun onInstallResult(installResult: InstallResult) {
         // skip this screen, if there are no apps to install
-        if (installResult.isEmpty) viewModel.onNextClickedAfterInstallingApps()
+        if (installResult.isFinished && installResult.isEmpty) {
+            viewModel.onNextClickedAfterInstallingApps()
+        }
 
         // if finished, treat all still queued apps as failed and resort/redisplay adapter items
         if (installResult.isFinished) {


### PR DESCRIPTION
We emit the install result of APKs at least two times. When there is no APKs to install, because APK backup was disabled, we would start the restore of app data two times.

This fix waits until the emitted install result is considered finished, so we only start data restore once.