### PR TITLE
Tolerate unexpected exceptions in DocumentsStorage and ApkRestore

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkRestore.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkRestore.kt
@@ -76,6 +76,9 @@ internal class ApkRestore(
             } catch (e: TimeoutCancellationException) {
                 Log.e(TAG, "Timeout while re-installing APK for $packageName.", e)
                 emit(installResult.fail(packageName))
+            } catch (e: Exception) {
+                Log.e(TAG, "Unexpected exception while re-installing APK for $packageName.", e)
+                emit(installResult.fail(packageName))
             }
         }
         installResult.isFinished = true

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/ApkBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/ApkBackup.kt
@@ -17,7 +17,6 @@ import com.stevesoltys.seedvault.metadata.PackageState
 import com.stevesoltys.seedvault.settings.SettingsManager
 import java.io.File
 import java.io.FileInputStream
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
@@ -145,10 +144,8 @@ internal class ApkBackup(
         val apk = File(apkPath)
         return try {
             apk.inputStream()
-        } catch (e: FileNotFoundException) {
-            Log.e(TAG, "Error opening ${apk.absolutePath} for backup.", e)
-            throw IOException(e)
-        } catch (e: SecurityException) {
+        } catch (e: Exception) {
+            // SAF may throw all sorts of exceptions, so wrap them in IOException
             Log.e(TAG, "Error opening ${apk.absolutePath} for backup.", e)
             throw IOException(e)
         }


### PR DESCRIPTION
Normally, it isn't good practice to catch general exceptions, but SAF is throwing all kinds of (even runtime) exceptions and we don't have any crash reporting. So until we have that, better to play things safe.

Fixes #305 