### PR TITLE
Don't include empty dirs in media backup

### DIFF
--- a/storage/lib/src/main/java/org/calyxos/backup/storage/backup/Backup.kt
+++ b/storage/lib/src/main/java/org/calyxos/backup/storage/backup/Backup.kt
@@ -22,7 +22,6 @@ import org.calyxos.backup.storage.scanner.FileScannerResult
 import java.io.IOException
 import java.security.GeneralSecurityException
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 internal class BackupResult(
     val chunkIds: Set<String>,
@@ -86,7 +85,6 @@ internal class Backup(
     )
 
     @Throws(IOException::class, GeneralSecurityException::class)
-    @OptIn(ExperimentalTime::class)
     suspend fun runBackup(backupObserver: BackupObserver?) {
         backupObserver?.onStartScanning()
         var duration: Duration? = null
@@ -121,7 +119,6 @@ internal class Backup(
     }
 
     @Throws(IOException::class, GeneralSecurityException::class)
-    @OptIn(ExperimentalTime::class)
     private suspend fun backupFiles(
         filesResult: FileScannerResult,
         availableChunkIds: HashSet<String>,

--- a/storage/lib/src/main/java/org/calyxos/backup/storage/restore/Restore.kt
+++ b/storage/lib/src/main/java/org/calyxos/backup/storage/restore/Restore.kt
@@ -154,13 +154,13 @@ internal class Restore(
 @Throws(IOException::class, GeneralSecurityException::class)
 internal fun InputStream.readVersion(expectedVersion: Int? = null): Int {
     val version = read()
-    if (version == -1) throw IOException()
+    if (version == -1) throw IOException("File empty!")
     if (expectedVersion != null && version != expectedVersion) {
         throw GeneralSecurityException("Expected version $expectedVersion, not $version")
     }
     if (version > Backup.VERSION) {
         // TODO maybe throw a different exception here and tell the user?
-        throw IOException()
+        throw IOException("Got version $version which is higher than what is supported.")
     }
     return version
 }


### PR DESCRIPTION
Otherwise, the directories would be treated as small files and we would try to backup their content which would fail.
Non-empty directories still get restored when we restore the files in them.

How to test: Tell Seedvault to backup Downloads, then use file manager to create a folder inside `/sdcard/Download`.

Fixes one bug of #336