### PR TITLE
Include user profile name in backup name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ It uses the same internal APIs as `adb backup` which is deprecated and thus need
 * `android.permission.MANAGE_USB` to access the serial number of USB mass storage devices.
 * `android.permission.WRITE_SECURE_SETTINGS` to change system backup settings and enable call log backup.
 * `android.permission.QUERY_ALL_PACKAGES` to get information about all installed apps for backup.
+* `android.permission.QUERY_USERS` to get the name of the user profile that gets backed up.
 * `android.permission.INSTALL_PACKAGES` to re-install apps when restoring from backup.
 * `android.permission.MANAGE_EXTERNAL_STORAGE` to backup and restore files from device storage.
 * `android.permission.ACCESS_MEDIA_LOCATION` to backup original media files e.g. without stripped EXIF metadata.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,10 @@
         android:name="android.permission.READ_LOGS"
         tools:ignore="ProtectedPermissions" />
 
+    <!-- Used to get the name of the current profile -->
+    <uses-permission android:name="android.permission.QUERY_USERS"
+        tools:ignore="ProtectedPermissions" />
+
     <!-- Used for periodic storage backups -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 

--- a/app/src/test/java/com/stevesoltys/seedvault/metadata/MetadataManagerTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/metadata/MetadataManagerTest.kt
@@ -6,6 +6,8 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.ApplicationInfo.FLAG_ALLOW_BACKUP
 import android.content.pm.ApplicationInfo.FLAG_SYSTEM
 import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.UserManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stevesoltys.seedvault.Clock
 import com.stevesoltys.seedvault.TestApp
@@ -94,11 +96,15 @@ class MetadataManagerTest {
     }
 
     @Test
-    fun `test onDeviceInitialization()`() {
+    fun `test onDeviceInitialization() without user permission`() {
         every { clock.time() } returns time
         every { crypto.getRandomBytes(METADATA_SALT_SIZE) } returns saltBytes
         expectReadFromCache()
         expectModifyMetadata(initialMetadata)
+
+        every {
+            context.checkSelfPermission("android.permission.QUERY_USERS")
+        } returns PackageManager.PERMISSION_DENIED
 
         manager.onDeviceInitialization(token)
 
@@ -108,6 +114,37 @@ class MetadataManagerTest {
         verify {
             cacheInputStream.close()
             cacheOutputStream.close()
+        }
+    }
+
+    @Test
+    fun `test onDeviceInitialization() with user permission`() {
+        val userManager: UserManager = mockk()
+        val userName = getRandomString()
+        val newMetadata = initialMetadata.copy(
+            deviceName = initialMetadata.deviceName + " - $userName",
+        )
+
+        every { clock.time() } returns time
+        every { crypto.getRandomBytes(METADATA_SALT_SIZE) } returns saltBytes
+        expectReadFromCache()
+        expectModifyMetadata(newMetadata)
+
+        every {
+            context.checkSelfPermission("android.permission.QUERY_USERS")
+        } returns PackageManager.PERMISSION_GRANTED
+        every { context.getSystemService(UserManager::class.java) } returns userManager
+        every { userManager.userName } returns userName
+
+        manager.onDeviceInitialization(token)
+
+        assertEquals(token, manager.getBackupToken())
+        assertEquals(0L, manager.getLastBackupTime())
+
+        verify {
+            cacheInputStream.close()
+            cacheOutputStream.close()
+            userManager.userName
         }
     }
 

--- a/permissions_com.stevesoltys.seedvault.xml
+++ b/permissions_com.stevesoltys.seedvault.xml
@@ -5,6 +5,7 @@
         <permission name="android.permission.MANAGE_USB"/>
         <permission name="android.permission.INSTALL_PACKAGES"/>
         <permission name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
+        <permission name="android.permission.QUERY_USERS" />
         <permission name="android.permission.READ_LOGS"/>
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
         <permission name="android.permission.MANAGE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
so it is easier to identify the right backup if more users backup to the same storage medium.

Closes #442