### PR TITLE
BackupScreen: Don't hardcode model name for internal storage

### DIFF
--- a/app/src/androidTest/java/com/stevesoltys/seedvault/e2e/screen/impl/BackupScreen.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/e2e/screen/impl/BackupScreen.kt
@@ -1,5 +1,6 @@
 package com.stevesoltys.seedvault.e2e.screen.impl
 
+import android.os.Build
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.BySelector
 import com.stevesoltys.seedvault.e2e.screen.UiDeviceScreen
@@ -16,7 +17,7 @@ object BackupScreen : UiDeviceScreen<BackupScreen>() {
 
     val backupSwitch = findObject { text("Backup my apps") }
 
-    val internalStorageButton = findObject { textContains("Android SDK built for") }
+    val internalStorageButton = findObject { textContains(Build.MODEL) }
 
     val useAnywayButton = findObject { text("USE ANYWAY") }
 


### PR DESCRIPTION
## Summary

This fixes running tests locally on different devices and non-CI images.

## Issue

The `backup and restore applications` test otherwise fails with the following exception after timeout:

```shell
androidx.test.uiautomator.UiObjectNotFoundException: UiSelector[CONTAINS_TEXT=Android SDK built for]
at androidx.test.uiautomator.UiObject.clickAndWaitForNewWindow(UiObject.java:456)
at androidx.test.uiautomator.UiObject.clickAndWaitForNewWindow(UiObject.java:434)
at com.stevesoltys.seedvault.e2e.LargeTestBase$chooseStorageLocation$2.invoke(LargeTestBase.kt:212)
at com.stevesoltys.seedvault.e2e.LargeTestBase$chooseStorageLocation$2.invoke(LargeTestBase.kt:211)
at com.stevesoltys.seedvault.e2e.screen.UiDeviceScreen.invoke(UiDeviceScreen.kt:19)
at com.stevesoltys.seedvault.e2e.LargeTestBase$DefaultImpls.chooseStorageLocation(LargeTestBase.kt:211)
at com.stevesoltys.seedvault.e2e.LargeBackupTestBase$DefaultImpls.chooseStorageLocation(LargeBackupTestBase.kt:22)
at com.stevesoltys.seedvault.e2e.SeedvaultLargeTest.chooseStorageLocation(SeedvaultLargeTest.kt:16)
at com.stevesoltys.seedvault.e2e.LargeTestBase$DefaultImpls.chooseStorageLocation$default(LargeTestBase.kt:180)
at com.stevesoltys.seedvault.e2e.impl.BackupRestoreTest.backup and restore applications(BackupRestoreTest.kt:21)
```

## Test

Ensure tests pass locally