### PR TITLE
Auto-disable apps that cancel the entire backup

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -2,6 +2,7 @@ package com.stevesoltys.seedvault
 
 import android.Manifest.permission.INTERACT_ACROSS_USERS_FULL
 import android.app.Application
+import android.app.backup.BackupManager
 import android.app.backup.BackupManager.PACKAGE_MANAGER_SENTINEL
 import android.app.backup.IBackupManager
 import android.content.Context
@@ -147,9 +148,10 @@ open class App : Application() {
 
 }
 
-const val MAGIC_PACKAGE_MANAGER = PACKAGE_MANAGER_SENTINEL
+const val MAGIC_PACKAGE_MANAGER: String = PACKAGE_MANAGER_SENTINEL
 const val ANCESTRAL_RECORD_KEY = "@ancestral_record@"
 const val GLOBAL_METADATA_KEY = "@meta@"
+const val ERROR_BACKUP_CANCELLED: Int = BackupManager.ERROR_BACKUP_CANCELLED
 
 // TODO this doesn't work for LineageOS as they do public debug builds
 fun isDebugBuild() = Build.TYPE == "userdebug"

--- a/app/src/main/java/com/stevesoltys/seedvault/BackupMonitor.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/BackupMonitor.kt
@@ -3,6 +3,8 @@ package com.stevesoltys.seedvault
 import android.app.backup.BackupManagerMonitor.EXTRA_LOG_EVENT_CATEGORY
 import android.app.backup.BackupManagerMonitor.EXTRA_LOG_EVENT_ID
 import android.app.backup.BackupManagerMonitor.EXTRA_LOG_EVENT_PACKAGE_NAME
+import android.app.backup.BackupManagerMonitor.EXTRA_LOG_PREFLIGHT_ERROR
+import android.app.backup.BackupManagerMonitor.LOG_EVENT_ID_ERROR_PREFLIGHT
 import android.app.backup.IBackupManagerMonitor
 import android.os.Bundle
 import android.util.Log
@@ -13,10 +15,16 @@ private val TAG = BackupMonitor::class.java.name
 class BackupMonitor : IBackupManagerMonitor.Stub() {
 
     override fun onEvent(bundle: Bundle) {
+        val id = bundle.getInt(EXTRA_LOG_EVENT_ID)
+        val packageName = bundle.getString(EXTRA_LOG_EVENT_PACKAGE_NAME, "?")
+        if (id == LOG_EVENT_ID_ERROR_PREFLIGHT) {
+            val preflightResult = bundle.getLong(EXTRA_LOG_PREFLIGHT_ERROR, -1)
+            Log.w(TAG, "Pre-flight error from $packageName: $preflightResult")
+        }
         if (!Log.isLoggable(TAG, DEBUG)) return
-        Log.d(TAG, "ID: " + bundle.getInt(EXTRA_LOG_EVENT_ID))
+        Log.d(TAG, "ID: $id")
         Log.d(TAG, "CATEGORY: " + bundle.getInt(EXTRA_LOG_EVENT_CATEGORY, -1))
-        Log.d(TAG, "PACKAGE: " + bundle.getString(EXTRA_LOG_EVENT_PACKAGE_NAME, "?"))
+        Log.d(TAG, "PACKAGE: $packageName")
     }
 
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
@@ -166,6 +166,15 @@ class SettingsManager(private val context: Context) {
 
     fun isBackupEnabled(packageName: String) = !blacklistedApps.contains(packageName)
 
+    /**
+     * Disables backup for an app. Similar to [onAppBackupStatusChanged].
+     */
+    fun disableBackup(packageName: String) {
+        if (blacklistedApps.add(packageName)) {
+            prefs.edit().putStringSet(PREF_KEY_BACKUP_APP_BLACKLIST, blacklistedApps).apply()
+        }
+    }
+
     fun isStorageBackupEnabled() = prefs.getBoolean(PREF_KEY_BACKUP_STORAGE, false)
 
     @UiThread


### PR DESCRIPTION
This can happen when the app process gets killed while its BackupAgent is running. There are several qcom apps in the wild that have this issue. These are DoSing our backups and are non-free, so we are defending ourselves against them.

Fixes #491