### PR TITLE
Always update next scheduling time in UI

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
@@ -275,13 +275,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
             backupScheduling.summary = getString(R.string.settings_backup_status_next_backup_usb)
             return
         }
-        if (workInfo == null) return
 
-        val nextScheduleTimeMillis = workInfo.nextScheduleTimeMillis
-        if (workInfo.state == WorkInfo.State.RUNNING) {
+        val nextScheduleTimeMillis = workInfo?.nextScheduleTimeMillis ?: Long.MAX_VALUE
+        if (workInfo != null && workInfo.state == WorkInfo.State.RUNNING) {
             val text = getString(R.string.notification_title)
             backupScheduling.summary = getString(R.string.settings_backup_status_next_backup, text)
         } else if (nextScheduleTimeMillis == Long.MAX_VALUE) {
+            Log.i(TAG, "No backup scheduled! workInfo: $workInfo")
             val text = getString(R.string.settings_backup_last_backup_never)
             backupScheduling.summary = getString(R.string.settings_backup_status_next_backup, text)
         } else {

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -51,7 +51,7 @@
             app:icon="@drawable/ic_access_time"
             app:key="backup_scheduling"
             app:title="@string/settings_backup_scheduling_title"
-            app:summary="Next backup: Never" />
+            tools:summary="Next backup: Never" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Also avoid hard-coded strings and log when no backups are scheduled.

Fixes #651