### PR TITLE
Warn users when they run out of space

### DIFF
--- a/app/src/androidTest/java/com/stevesoltys/seedvault/KoinInstrumentationTestApp.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/KoinInstrumentationTestApp.kt
@@ -32,7 +32,7 @@ class KoinInstrumentationTestApp : App() {
 
             single { spyk(BackupNotificationManager(context)) }
             single { spyk(FullBackup(get(), get(), get(), get(), get())) }
-            single { spyk(KVBackup(get(), get(), get(), get(), get())) }
+            single { spyk(KVBackup(get(), get(), get(), get(), get(), get())) }
             single { spyk(InputFactory()) }
 
             single { spyk(FullRestore(get(), get(), get(), get(), get())) }

--- a/app/src/androidTest/java/com/stevesoltys/seedvault/KoinInstrumentationTestApp.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/KoinInstrumentationTestApp.kt
@@ -31,7 +31,7 @@ class KoinInstrumentationTestApp : App() {
             single { spyk(SettingsManager(context)) }
 
             single { spyk(BackupNotificationManager(context)) }
-            single { spyk(FullBackup(get(), get(), get(), get())) }
+            single { spyk(FullBackup(get(), get(), get(), get(), get())) }
             single { spyk(KVBackup(get(), get(), get(), get(), get())) }
             single { spyk(InputFactory()) }
 

--- a/app/src/androidTest/java/com/stevesoltys/seedvault/PluginTest.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/PluginTest.kt
@@ -70,6 +70,17 @@ class PluginTest : KoinComponent {
         assertNotNull(storagePlugin.providerPackageName)
     }
 
+    @Test
+    fun testTest() = runBlocking(Dispatchers.IO) {
+        assertTrue(storagePlugin.test())
+    }
+
+    @Test
+    fun testGetFreeSpace() = runBlocking(Dispatchers.IO) {
+        val freeBytes = storagePlugin.getFreeSpace() ?: error("no free space retrieved")
+        assertTrue(freeBytes > 0)
+    }
+
     /**
      * This test initializes the storage three times while creating two new restore sets.
      *

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/Metadata.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/Metadata.kt
@@ -20,7 +20,12 @@ data class BackupMetadata(
     internal val deviceName: String = "${Build.MANUFACTURER} ${Build.MODEL}",
     internal var d2dBackup: Boolean = false,
     internal val packageMetadataMap: PackageMetadataMap = PackageMetadataMap(),
-)
+) {
+    val size: Long?
+        get() = packageMetadataMap.values.sumOf { m ->
+            (m.size ?: 0L) + (m.splits?.sumOf { it.size ?: 0L } ?: 0L)
+        }
+}
 
 internal const val JSON_METADATA = "@meta@"
 internal const val JSON_METADATA_VERSION = "version"
@@ -89,6 +94,7 @@ data class PackageMetadata(
 
 data class ApkSplit(
     val name: String,
+    val size: Long?,
     val sha256: String,
     // There's also a revisionCode, but it doesn't seem to be used just yet
 )

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataManager.kt
@@ -58,6 +58,8 @@ internal class MetadataManager(
             return field
         }
 
+    val backupSize: Long? get() = metadata.size
+
     /**
      * Call this when initializing a new device.
      *

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataReader.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataReader.kt
@@ -169,6 +169,9 @@ internal class MetadataReaderImpl(private val crypto: Crypto) : MetadataReader {
             val jsonApkSplit = jsonSplits.getJSONObject(i)
             val apkSplit = ApkSplit(
                 name = jsonApkSplit.getString(JSON_PACKAGE_SPLIT_NAME),
+                size = jsonApkSplit.optLong(JSON_PACKAGE_SIZE, -1L).let {
+                    if (it < 0L) null else it
+                },
                 sha256 = jsonApkSplit.getString(JSON_PACKAGE_SHA256)
             )
             splits.add(apkSplit)

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataWriter.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataWriter.kt
@@ -61,6 +61,7 @@ internal class MetadataWriterImpl(private val crypto: Crypto) : MetadataWriter {
                     put(JSON_PACKAGE_SPLITS, JSONArray().apply {
                         for (split in splits) put(JSONObject().apply {
                             put(JSON_PACKAGE_SPLIT_NAME, split.name)
+                            if (split.size != null) put(JSON_PACKAGE_SIZE, split.size)
                             put(JSON_PACKAGE_SHA256, split.sha256)
                         })
                     })

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/StoragePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/StoragePlugin.kt
@@ -14,6 +14,13 @@ interface StoragePlugin<T> {
     suspend fun test(): Boolean
 
     /**
+     * Retrieves the available storage space in bytes.
+     * @return the number of bytes available or null if the number is unknown.
+     * Returning a negative number or zero to indicate unknown is discouraged.
+     */
+    suspend fun getFreeSpace(): Long?
+
+    /**
      * Start a new [RestoreSet] with the given token.
      *
      * This is typically followed by a call to [initializeDevice].

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/StoragePluginManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/StoragePluginManager.kt
@@ -6,6 +6,7 @@
 package com.stevesoltys.seedvault.plugins
 
 import android.content.Context
+import android.util.Log
 import androidx.annotation.WorkerThread
 import com.stevesoltys.seedvault.getStorageContext
 import com.stevesoltys.seedvault.permitDiskReads
@@ -129,6 +130,19 @@ class StoragePluginManager(
         val storage = storageProperties ?: return false
         val systemContext = context.getStorageContext { storage.isUsb }
         return storage.isUnavailableUsb(systemContext)
+    }
+
+    /**
+     * Retrieves the amount of free space in bytes, or null if unknown.
+     */
+    @WorkerThread
+    suspend fun getFreeSpace(): Long? {
+        return try {
+            appPlugin.getFreeSpace()
+        } catch (e: Exception) {
+            Log.e("StoragePluginManager", "Error getting free space: ", e)
+            null
+        }
     }
 
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/StorageProperties.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/StorageProperties.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
 import androidx.annotation.WorkerThread
+import java.io.IOException
 
 abstract class StorageProperties<T> {
     abstract val config: T
@@ -33,4 +34,8 @@ abstract class StorageProperties<T> {
         val capabilities = cm.getNetworkCapabilities(cm.activeNetwork) ?: return false
         return capabilities.hasCapability(NET_CAPABILITY_INTERNET) && (allowMetered || !isMetered)
     }
+}
+
+fun Exception.isOutOfSpace(): Boolean {
+    return this is IOException && message?.contains("No space left on device") == true
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/StorageProperties.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/StorageProperties.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
 import androidx.annotation.WorkerThread
+import at.bitfire.dav4jvm.exception.HttpException
 import java.io.IOException
 
 abstract class StorageProperties<T> {
@@ -37,5 +38,12 @@ abstract class StorageProperties<T> {
 }
 
 fun Exception.isOutOfSpace(): Boolean {
-    return this is IOException && message?.contains("No space left on device") == true
+    return when (this) {
+        is IOException -> message?.contains("No space left on device") == true ||
+            (cause as? HttpException)?.code == 507
+
+        is HttpException -> code == 507
+
+        else -> false
+    }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
@@ -158,13 +158,14 @@ internal suspend fun DocumentFile.createOrGetFile(
             if (this.name != name) {
                 throw IOException("File named ${this.name}, but should be $name")
             }
-        } ?: throw IOException()
+        } ?: throw IOException("could not find nor create")
     } catch (e: Exception) {
         // SAF can throw all sorts of exceptions, so wrap it in IOException.
         // E.g. IllegalArgumentException can be thrown by FileSystemProvider#isChildDocument()
         // when flash drive is not plugged-in:
         // http://aosp.opersys.com/xref/android-11.0.0_r8/xref/frameworks/base/core/java/com/android/internal/content/FileSystemProvider.java#135
-        throw IOException(e)
+        if (e is IOException) throw e
+        else throw IOException(e)
     }
 }
 

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/SafHandler.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/SafHandler.kt
@@ -40,7 +40,7 @@ internal class SafHandler(
         } else {
             safOption.title
         }
-        return SafStorage(uri, name, safOption.isUsb, safOption.requiresNetwork)
+        return SafStorage(uri, name, safOption.isUsb, safOption.requiresNetwork, safOption.rootId)
     }
 
     /**

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/SafStorage.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/SafStorage.kt
@@ -7,6 +7,7 @@ package com.stevesoltys.seedvault.plugins.saf
 
 import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract.Root.COLUMN_ROOT_ID
 import androidx.annotation.WorkerThread
 import androidx.documentfile.provider.DocumentFile
 import com.stevesoltys.seedvault.plugins.StorageProperties
@@ -16,6 +17,11 @@ data class SafStorage(
     override val name: String,
     override val isUsb: Boolean,
     override val requiresNetwork: Boolean,
+    /**
+     * The [COLUMN_ROOT_ID] for the [uri].
+     * This is only nullable for historic reasons, because we didn't always store it.
+     */
+    val rootId: String?,
 ) : StorageProperties<Uri>() {
 
     val uri: Uri = config

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestorableBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestorableBackup.kt
@@ -20,6 +20,9 @@ data class RestorableBackup(val backupMetadata: BackupMetadata) {
     val time: Long
         get() = backupMetadata.time
 
+    val size: Long?
+        get() = backupMetadata.size
+
     val deviceName: String
         get() = backupMetadata.deviceName
 

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreSetAdapter.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreSetAdapter.kt
@@ -3,8 +3,11 @@ package com.stevesoltys.seedvault.restore
 import android.text.format.DateUtils.FORMAT_ABBREV_RELATIVE
 import android.text.format.DateUtils.HOUR_IN_MILLIS
 import android.text.format.DateUtils.getRelativeTimeSpanString
+import android.text.format.Formatter
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView.Adapter
@@ -33,6 +36,7 @@ internal class RestoreSetAdapter(
 
         private val titleView = v.requireViewById<TextView>(R.id.titleView)
         private val subtitleView = v.requireViewById<TextView>(R.id.subtitleView)
+        private val sizeView = v.requireViewById<TextView>(R.id.sizeView)
 
         internal fun bind(item: RestorableBackup) {
             v.setOnClickListener { listener.onRestorableBackupClicked(item) }
@@ -42,6 +46,16 @@ internal class RestoreSetAdapter(
             val setup = getRelativeTime(item.token)
             subtitleView.text =
                 v.context.getString(R.string.restore_restore_set_times, lastBackup, setup)
+            val size = item.size
+            if (size == null) {
+                sizeView.visibility = GONE
+            } else {
+                sizeView.text = v.context.getString(
+                    R.string.restore_restore_set_size,
+                    Formatter.formatShortFileSize(v.context, size),
+                )
+                sizeView.visibility = VISIBLE
+            }
         }
 
         private fun getRelativeTime(time: Long): CharSequence {

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreSetFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreSetFragment.kt
@@ -44,9 +44,9 @@ class RestoreSetFragment : Fragment() {
         // decryption will fail when the device is locked, so keep the screen on to prevent locking
         requireActivity().window.addFlags(FLAG_KEEP_SCREEN_ON)
 
-        viewModel.restoreSetResults.observe(viewLifecycleOwner, { result ->
+        viewModel.restoreSetResults.observe(viewLifecycleOwner) { result ->
             onRestoreResultsLoaded(result)
-        })
+        }
 
         skipView.setOnClickListener {
             viewModel.onFinishClickedAfterRestoringAppData()
@@ -72,7 +72,10 @@ class RestoreSetFragment : Fragment() {
             listView.visibility = VISIBLE
             progressBar.visibility = INVISIBLE
 
-            listView.adapter = RestoreSetAdapter(viewModel, results.restorableBackups)
+            listView.adapter = RestoreSetAdapter(
+                listener = viewModel,
+                items = results.restorableBackups.sortedByDescending { it.time },
+            )
         }
     }
 

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
@@ -32,6 +32,7 @@ internal enum class StoragePluginType { // don't rename, will break existing ins
 }
 
 private const val PREF_KEY_STORAGE_URI = "storageUri"
+private const val PREF_KEY_STORAGE_ROOT_ID = "storageRootId"
 private const val PREF_KEY_STORAGE_NAME = "storageName"
 private const val PREF_KEY_STORAGE_IS_USB = "storageIsUsb"
 private const val PREF_KEY_STORAGE_REQUIRES_NETWORK = "storageRequiresNetwork"
@@ -136,6 +137,7 @@ class SettingsManager(private val context: Context) {
     fun setSafStorage(safStorage: SafStorage) {
         prefs.edit()
             .putString(PREF_KEY_STORAGE_URI, safStorage.uri.toString())
+            .putString(PREF_KEY_STORAGE_ROOT_ID, safStorage.rootId)
             .putString(PREF_KEY_STORAGE_NAME, safStorage.name)
             .putBoolean(PREF_KEY_STORAGE_IS_USB, safStorage.isUsb)
             .putBoolean(PREF_KEY_STORAGE_REQUIRES_NETWORK, safStorage.requiresNetwork)
@@ -149,7 +151,8 @@ class SettingsManager(private val context: Context) {
             ?: throw IllegalStateException("no storage name")
         val isUsb = prefs.getBoolean(PREF_KEY_STORAGE_IS_USB, false)
         val requiresNetwork = prefs.getBoolean(PREF_KEY_STORAGE_REQUIRES_NETWORK, false)
-        return SafStorage(uri, name, isUsb, requiresNetwork)
+        val rootId = prefs.getString(PREF_KEY_STORAGE_ROOT_ID, null)
+        return SafStorage(uri, name, isUsb, requiresNetwork, rootId)
     }
 
     fun setFlashDrive(usb: FlashDrive?) {

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -360,6 +360,9 @@ internal class BackupCoordinator(
                         onPackageBackedUp(packageInfo, BackupType.KV, size)
                     } catch (e: Exception) {
                         Log.e(TAG, "Error calling onPackageBackedUp for $packageName", e)
+                        if (e is IOException &&
+                            e.message?.contains("No space left on device") == true
+                        ) nm.onInsufficientSpaceError()
                         result = TRANSPORT_PACKAGE_REJECTED
                     }
                 }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -26,6 +26,7 @@ import com.stevesoltys.seedvault.metadata.PackageState.QUOTA_EXCEEDED
 import com.stevesoltys.seedvault.metadata.PackageState.UNKNOWN_ERROR
 import com.stevesoltys.seedvault.plugins.StoragePlugin
 import com.stevesoltys.seedvault.plugins.StoragePluginManager
+import com.stevesoltys.seedvault.plugins.isOutOfSpace
 import com.stevesoltys.seedvault.plugins.saf.FILE_BACKUP_METADATA
 import com.stevesoltys.seedvault.settings.SettingsManager
 import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
@@ -360,9 +361,7 @@ internal class BackupCoordinator(
                         onPackageBackedUp(packageInfo, BackupType.KV, size)
                     } catch (e: Exception) {
                         Log.e(TAG, "Error calling onPackageBackedUp for $packageName", e)
-                        if (e is IOException &&
-                            e.message?.contains("No space left on device") == true
-                        ) nm.onInsufficientSpaceError()
+                        if (e.isOutOfSpace()) nm.onInsufficientSpaceError()
                         result = TRANSPORT_PACKAGE_REJECTED
                     }
                 }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -382,6 +382,7 @@ internal class BackupCoordinator(
                 onPackageBackedUp(packageInfo, BackupType.FULL, size)
             } catch (e: Exception) {
                 Log.e(TAG, "Error calling onPackageBackedUp for $packageName", e)
+                if (e.isOutOfSpace()) nm.onInsufficientSpaceError()
                 result = TRANSPORT_PACKAGE_REJECTED
             }
             result

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
@@ -28,6 +28,7 @@ val backupModule = module {
         FullBackup(
             pluginManager = get(),
             settingsManager = get(),
+            nm = get(),
             inputFactory = get(),
             crypto = get(),
         )

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
@@ -19,6 +19,7 @@ val backupModule = module {
         KVBackup(
             pluginManager = get(),
             settingsManager = get(),
+            nm = get(),
             inputFactory = get(),
             crypto = get(),
             dbManager = get(),

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/FullBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/FullBackup.kt
@@ -12,7 +12,9 @@ import com.stevesoltys.seedvault.crypto.Crypto
 import com.stevesoltys.seedvault.header.VERSION
 import com.stevesoltys.seedvault.header.getADForFull
 import com.stevesoltys.seedvault.plugins.StoragePluginManager
+import com.stevesoltys.seedvault.plugins.isOutOfSpace
 import com.stevesoltys.seedvault.settings.SettingsManager
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import libcore.io.IoUtils.closeQuietly
 import java.io.EOFException
 import java.io.IOException
@@ -41,6 +43,7 @@ private val TAG = FullBackup::class.java.simpleName
 internal class FullBackup(
     private val pluginManager: StoragePluginManager,
     private val settingsManager: SettingsManager,
+    private val nm: BackupNotificationManager,
     private val inputFactory: InputFactory,
     private val crypto: Crypto,
 ) {
@@ -170,6 +173,7 @@ internal class FullBackup(
             TRANSPORT_OK
         } catch (e: IOException) {
             Log.e(TAG, "Error handling backup data for ${state.packageName}: ", e)
+            if (e.isOutOfSpace()) nm.onInsufficientSpaceError()
             TRANSPORT_ERROR
         }
     }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackup.kt
@@ -14,7 +14,9 @@ import com.stevesoltys.seedvault.crypto.Crypto
 import com.stevesoltys.seedvault.header.VERSION
 import com.stevesoltys.seedvault.header.getADForKV
 import com.stevesoltys.seedvault.plugins.StoragePluginManager
+import com.stevesoltys.seedvault.plugins.isOutOfSpace
 import com.stevesoltys.seedvault.settings.SettingsManager
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import java.io.IOException
 import java.util.zip.GZIPOutputStream
 
@@ -34,6 +36,7 @@ private val TAG = KVBackup::class.java.simpleName
 internal class KVBackup(
     private val pluginManager: StoragePluginManager,
     private val settingsManager: SettingsManager,
+    private val nm: BackupNotificationManager,
     private val inputFactory: InputFactory,
     private val crypto: Crypto,
     private val dbManager: KvDbManager,
@@ -214,6 +217,7 @@ internal class KVBackup(
             TRANSPORT_OK
         } catch (e: IOException) {
             Log.e(TAG, "Error uploading DB", e)
+            if (e.isOutOfSpace()) nm.onInsufficientSpaceError()
             TRANSPORT_ERROR
         } finally {
             this.state = null

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
@@ -17,6 +17,7 @@ import android.text.format.Formatter
 import android.util.Log
 import androidx.core.app.NotificationCompat.Action
 import androidx.core.app.NotificationCompat.Builder
+import androidx.core.app.NotificationCompat.CATEGORY_ERROR
 import androidx.core.app.NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE
 import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
 import androidx.core.app.NotificationCompat.PRIORITY_HIGH
@@ -36,9 +37,10 @@ private const val CHANNEL_ID_RESTORE_ERROR = "NotificationRestoreError"
 internal const val NOTIFICATION_ID_OBSERVER = 1
 private const val NOTIFICATION_ID_SUCCESS = 2
 private const val NOTIFICATION_ID_ERROR = 3
-private const val NOTIFICATION_ID_RESTORE_ERROR = 4
-private const val NOTIFICATION_ID_BACKGROUND = 5
-private const val NOTIFICATION_ID_NO_MAIN_KEY_ERROR = 6
+private const val NOTIFICATION_ID_SPACE_ERROR = 4
+private const val NOTIFICATION_ID_RESTORE_ERROR = 5
+private const val NOTIFICATION_ID_BACKGROUND = 6
+private const val NOTIFICATION_ID_NO_MAIN_KEY_ERROR = 7
 
 private val TAG = BackupNotificationManager::class.java.simpleName
 
@@ -212,6 +214,20 @@ internal class BackupNotificationManager(private val context: Context) {
 
     fun onBackupErrorSeen() {
         nm.cancel(NOTIFICATION_ID_ERROR)
+    }
+
+    fun onInsufficientSpaceError() {
+        val notification = Builder(context, CHANNEL_ID_ERROR).apply {
+            setSmallIcon(R.drawable.ic_cloud_error)
+            setContentTitle(context.getString(R.string.notification_space_error_title))
+            setContentText(context.getString(R.string.notification_space_error_text))
+            setWhen(System.currentTimeMillis())
+            setOnlyAlertOnce(true)
+            setAutoCancel(true)
+            setPriority(PRIORITY_HIGH)
+            setCategory(CATEGORY_ERROR)
+        }.build()
+        nm.notify(NOTIFICATION_ID_SPACE_ERROR, notification)
     }
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/ApkBackupManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/ApkBackupManager.kt
@@ -110,6 +110,9 @@ internal class ApkBackupManager(
             } ?: false
         } catch (e: IOException) {
             Log.e(TAG, "Error while writing APK for $packageName", e)
+            if (e.message?.contains("No space left on device") == true) {
+                nm.onInsufficientSpaceError()
+            }
             false
         }
     }

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/ApkBackupManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/ApkBackupManager.kt
@@ -13,6 +13,7 @@ import com.stevesoltys.seedvault.metadata.PackageState.NOT_ALLOWED
 import com.stevesoltys.seedvault.metadata.PackageState.WAS_STOPPED
 import com.stevesoltys.seedvault.plugins.StoragePlugin
 import com.stevesoltys.seedvault.plugins.StoragePluginManager
+import com.stevesoltys.seedvault.plugins.isOutOfSpace
 import com.stevesoltys.seedvault.plugins.saf.FILE_BACKUP_METADATA
 import com.stevesoltys.seedvault.settings.SettingsManager
 import com.stevesoltys.seedvault.transport.backup.PackageService
@@ -110,9 +111,7 @@ internal class ApkBackupManager(
             } ?: false
         } catch (e: IOException) {
             Log.e(TAG, "Error while writing APK for $packageName", e)
-            if (e.message?.contains("No space left on device") == true) {
-                nm.onInsufficientSpaceError()
-            }
+            if (e.isOutOfSpace()) nm.onInsufficientSpaceError()
             false
         }
     }

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/AppBackupWorker.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/AppBackupWorker.kt
@@ -120,7 +120,10 @@ class AppBackupWorker(
             if (isStopped) {
                 Result.retry()
             } else {
-                doBackup()
+                val result = doBackup()
+                // only allow retrying if rescheduling is allowed
+                if (tags.contains(TAG_RESCHEDULE)) return result
+                else Result.success()
             }
         } finally {
             // schedule next backup, because the old one gets lost

--- a/app/src/main/res/layout/list_item_restore_set.xml
+++ b/app/src/main/res/layout/list_item_restore_set.xml
@@ -33,14 +33,25 @@
 
     <TextView
         android:id="@+id/subtitleView"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:layout_marginBottom="16dp"
         android:textColor="?android:attr/textColorTertiary"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/titleView"
         app:layout_constraintTop_toBottomOf="@+id/titleView"
-        tools:text="Yesterday, 8:25 AM" />
+        tools:text="@string/restore_restore_set_times" />
+
+    <TextView
+        android:id="@+id/sizeView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/titleView"
+        app:layout_constraintTop_toBottomOf="@+id/subtitleView"
+        tools:text="Size: 5 GB" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,7 @@
     <string name="restore_title">Restore from backup</string>
     <string name="restore_choose_restore_set">Choose a backup to restore</string>
     <string name="restore_restore_set_times">Last backup %1$s · First %2$s.</string>
+    <string name="restore_restore_set_size">Size: <xliff:g example="1 GB" id="size">%1$s</xliff:g></string>
     <string name="restore_skip">Don\'t restore</string>
     <string name="restore_skip_apps">Skip restoring apps</string>
     <string name="restore_invalid_location_title">No backups found</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,9 @@
     <string name="notification_error_text">A device backup failed to run.</string>
     <string name="notification_error_action">Fix</string>
 
+    <string name="notification_space_error_title">Insufficient backup space</string>
+    <string name="notification_space_error_text">Your backup location is running out of space. Free up space, so backups can run.</string>
+
     <string name="notification_restore_error_channel_title">Auto restore flash drive error</string>
     <string name="notification_restore_error_title">Could not restore data for %1$s</string>
     <string name="notification_restore_error_text">Plug in your %1$s before installing the app to restore its data from backup.</string>

--- a/app/src/test/java/com/stevesoltys/seedvault/metadata/MetadataWriterDecoderTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/metadata/MetadataWriterDecoderTest.kt
@@ -61,9 +61,13 @@ internal class MetadataWriterDecoderTest {
                     version = Random.nextLong(),
                     installer = getRandomString(),
                     splits = listOf(
-                        ApkSplit(getRandomString(), getRandomString()),
-                        ApkSplit(getRandomString(), getRandomString()),
-                        ApkSplit(getRandomString(), getRandomString())
+                        ApkSplit(getRandomString(), null, getRandomString()),
+                        ApkSplit(getRandomString(), 0L, getRandomString()),
+                        ApkSplit(
+                            name = getRandomString(),
+                            size = Random.nextLong(0, Long.MAX_VALUE),
+                            sha256 = getRandomString(),
+                        ),
                     ),
                     sha256 = getRandomString(),
                     signatures = listOf(getRandomString(), getRandomString())

--- a/app/src/test/java/com/stevesoltys/seedvault/plugins/webdav/WebDavStoragePluginTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/plugins/webdav/WebDavStoragePluginTest.kt
@@ -42,6 +42,12 @@ internal class WebDavStoragePluginTest : TransportTest() {
     }
 
     @Test
+    fun `test getting free space`() = runBlocking {
+        val freeBytes = plugin.getFreeSpace() ?: fail()
+        assertTrue(freeBytes > 0)
+    }
+
+    @Test
     fun `test restore sets and reading+writing`() = runBlocking {
         val token = System.currentTimeMillis()
         val metadata = getRandomByteArray()

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkBackupRestoreTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkBackupRestoreTest.kt
@@ -76,7 +76,7 @@ internal class ApkBackupRestoreTest : TransportTest() {
         installer = getRandomString(),
         sha256 = "eHx5jjmlvBkQNVuubQzYejay4Q_QICqD47trAF2oNHI",
         signatures = listOf("AwIB"),
-        splits = listOf(ApkSplit(splitName, splitSha256))
+        splits = listOf(ApkSplit(splitName, Random.nextLong(), splitSha256))
     )
     private val packageMetadataMap: PackageMetadataMap = hashMapOf(packageName to packageMetadata)
     private val installerName = packageMetadata.installer

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkRestoreTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkRestoreTest.kt
@@ -269,8 +269,8 @@ internal class ApkRestoreTest : TransportTest() {
         val split2Name = getRandomString()
         packageMetadataMap[packageName] = packageMetadataMap[packageName]!!.copy(
             splits = listOf(
-                ApkSplit(split1Name, getRandomBase64()),
-                ApkSplit(split2Name, getRandomBase64())
+                ApkSplit(split1Name, Random.nextLong(), getRandomBase64()),
+                ApkSplit(split2Name, Random.nextLong(), getRandomBase64())
             )
         )
 
@@ -293,7 +293,7 @@ internal class ApkRestoreTest : TransportTest() {
         // add one APK split to metadata
         val splitName = getRandomString()
         packageMetadataMap[packageName] = packageMetadataMap[packageName]!!.copy(
-            splits = listOf(ApkSplit(splitName, getRandomBase64(23)))
+            splits = listOf(ApkSplit(splitName, Random.nextLong(), getRandomBase64(23)))
         )
 
         // cache APK and get icon as well as app name
@@ -318,7 +318,7 @@ internal class ApkRestoreTest : TransportTest() {
             val splitName = getRandomString()
             val sha256 = getRandomBase64(23)
             packageMetadataMap[packageName] = packageMetadataMap[packageName]!!.copy(
-                splits = listOf(ApkSplit(splitName, sha256))
+                splits = listOf(ApkSplit(splitName, Random.nextLong(), sha256))
             )
 
             // cache APK and get icon as well as app name
@@ -343,8 +343,8 @@ internal class ApkRestoreTest : TransportTest() {
         val split2sha256 = "ZqZ1cVH47lXbEncWx-Pc4L6AdLZOIO2lQuXB5GypxB4"
         packageMetadataMap[packageName] = packageMetadataMap[packageName]!!.copy(
             splits = listOf(
-                ApkSplit(split1Name, split1sha256),
-                ApkSplit(split2Name, split2sha256)
+                ApkSplit(split1Name, Random.nextLong(), split1sha256),
+                ApkSplit(split2Name, Random.nextLong(), split2sha256)
             )
         )
 

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
@@ -63,8 +63,14 @@ internal class CoordinatorIntegrationTest : TransportTest() {
     @Suppress("Deprecation")
     private val legacyPlugin = mockk<LegacyStoragePlugin>()
     private val backupPlugin = mockk<StoragePlugin<*>>()
-    private val kvBackup =
-        KVBackup(storagePluginManager, settingsManager, inputFactory, cryptoImpl, dbManager)
+    private val kvBackup = KVBackup(
+        pluginManager = storagePluginManager,
+        settingsManager = settingsManager,
+        nm = notificationManager,
+        inputFactory = inputFactory,
+        crypto = cryptoImpl,
+        dbManager = dbManager,
+    )
     private val fullBackup = FullBackup(
         pluginManager = storagePluginManager,
         settingsManager = settingsManager,

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
@@ -65,8 +65,13 @@ internal class CoordinatorIntegrationTest : TransportTest() {
     private val backupPlugin = mockk<StoragePlugin<*>>()
     private val kvBackup =
         KVBackup(storagePluginManager, settingsManager, inputFactory, cryptoImpl, dbManager)
-    private val fullBackup =
-        FullBackup(storagePluginManager, settingsManager, inputFactory, cryptoImpl)
+    private val fullBackup = FullBackup(
+        pluginManager = storagePluginManager,
+        settingsManager = settingsManager,
+        nm = notificationManager,
+        inputFactory = inputFactory,
+        crypto = cryptoImpl,
+    )
     private val apkBackup = mockk<ApkBackup>()
     private val packageService: PackageService = mockk()
     private val backup = BackupCoordinator(

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinatorTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinatorTest.kt
@@ -64,6 +64,7 @@ internal class BackupCoordinatorTest : BackupTest() {
         name = getRandomString(),
         isUsb = false,
         requiresNetwork = false,
+        rootId = null,
     )
 
     init {

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/FullBackupTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/FullBackupTest.kt
@@ -8,6 +8,7 @@ import com.stevesoltys.seedvault.header.VERSION
 import com.stevesoltys.seedvault.header.getADForFull
 import com.stevesoltys.seedvault.plugins.StoragePlugin
 import com.stevesoltys.seedvault.plugins.StoragePluginManager
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
@@ -26,7 +27,14 @@ internal class FullBackupTest : BackupTest() {
 
     private val storagePluginManager: StoragePluginManager = mockk()
     private val plugin = mockk<StoragePlugin<*>>()
-    private val backup = FullBackup(storagePluginManager, settingsManager, inputFactory, crypto)
+    private val notificationManager = mockk<BackupNotificationManager>()
+    private val backup = FullBackup(
+        pluginManager = storagePluginManager,
+        settingsManager = settingsManager,
+        nm = notificationManager,
+        inputFactory = inputFactory,
+        crypto = crypto,
+    )
 
     private val bytes = ByteArray(23).apply { Random.nextBytes(this) }
     private val inputStream = mockk<FileInputStream>()

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/KVBackupTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/KVBackupTest.kt
@@ -14,6 +14,7 @@ import com.stevesoltys.seedvault.header.VERSION
 import com.stevesoltys.seedvault.header.getADForKV
 import com.stevesoltys.seedvault.plugins.StoragePlugin
 import com.stevesoltys.seedvault.plugins.StoragePluginManager
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -34,10 +35,18 @@ import kotlin.random.Random
 internal class KVBackupTest : BackupTest() {
 
     private val pluginManager = mockk<StoragePluginManager>()
+    private val notificationManager = mockk<BackupNotificationManager>()
     private val dataInput = mockk<BackupDataInput>()
     private val dbManager = mockk<KvDbManager>()
 
-    private val backup = KVBackup(pluginManager, settingsManager, inputFactory, crypto, dbManager)
+    private val backup = KVBackup(
+        pluginManager = pluginManager,
+        settingsManager = settingsManager,
+        nm = notificationManager,
+        inputFactory = inputFactory,
+        crypto = crypto,
+        dbManager = dbManager
+    )
 
     private val db = mockk<KVDb>()
     private val plugin = mockk<StoragePlugin<*>>()

--- a/app/src/test/java/com/stevesoltys/seedvault/worker/ApkBackupTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/worker/ApkBackupTest.kt
@@ -208,8 +208,8 @@ internal class ApkBackupTest : BackupTest() {
             version = packageInfo.longVersionCode,
             installer = getRandomString(),
             splits = listOf(
-                ApkSplit(split1Name, split1Sha256),
-                ApkSplit(split2Name, split2Sha256)
+                ApkSplit(split1Name, split1Bytes.size.toLong(), split1Sha256),
+                ApkSplit(split2Name, split2Bytes.size.toLong(), split2Sha256)
             ),
             sha256 = "eHx5jjmlvBkQNVuubQzYejay4Q_QICqD47trAF2oNHI",
             signatures = packageMetadata.signatures


### PR DESCRIPTION
This PR takes two approaches for warning the user about out of space situations:

1. try to retrieve actual free space from backup location and warn the user before attempting a backup if this is very low. some hacks are used to get the free space from external storage SAF providers
2. catch exceptions that include hints about out of storage situations and then warn the user as soon as such an exception happens. Note that SAF does not always expose those exceptions to the caller.

Related to #363
Fixes #555