### PR TITLE
fixup! restore: Skip installing APKs if not allowed by policy

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
@@ -15,7 +15,7 @@ val installModule = module {
     factory { ApkSplitCompatibilityChecker(get()) }
     factory {
         ApkRestore(androidContext(), get(), get(), get(), get(), get()) {
-            androidContext().getSystemService(UserManager::class.java).isAllowedToInstallApks()
+            androidContext().getSystemService(UserManager::class.java)!!.isAllowedToInstallApks()
         }
     }
 }


### PR DESCRIPTION
Fixes AOSP QPR2 nullability build failure.

```
restore/install/InstallModule.kt:18:71: error: only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type UserManager?      
    androidContext().getSystemService(UserManager::class.java).isAllowedToInstallApks()
```