### PR TITLE
Use macOS 12 for test workflows, 11 will soon be deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   instrumentation_tests:
-    runs-on: macos-11
+    runs-on: macos-12
     if: github.repository == 'seedvault-app/seedvault'
     timeout-minutes: 80
     strategy:


### PR DESCRIPTION
More info: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/