### PR TITLE
Better scheduling co-existence with other transport

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -33,6 +33,7 @@ import com.stevesoltys.seedvault.settings.AppListRetriever
 import com.stevesoltys.seedvault.settings.SettingsManager
 import com.stevesoltys.seedvault.settings.SettingsViewModel
 import com.stevesoltys.seedvault.storage.storageModule
+import com.stevesoltys.seedvault.transport.TRANSPORT_ID
 import com.stevesoltys.seedvault.transport.backup.backupModule
 import com.stevesoltys.seedvault.transport.restore.restoreModule
 import com.stevesoltys.seedvault.ui.files.FileSelectionViewModel
@@ -185,12 +186,14 @@ open class App : Application() {
             return
         }
 
-        backupManager.setFrameworkSchedulingEnabledForUser(UserHandle.myUserId(), false)
-        if (backupManager.isBackupEnabled && !pluginManager.isOnRemovableDrive) {
-            AppBackupWorker.schedule(applicationContext, settingsManager, UPDATE)
+        if (backupManager.currentTransport == TRANSPORT_ID) {
+            backupManager.setFrameworkSchedulingEnabledForUser(UserHandle.myUserId(), false)
+            if (backupManager.isBackupEnabled && !pluginManager.isOnRemovableDrive) {
+                AppBackupWorker.schedule(applicationContext, settingsManager, UPDATE)
+            }
+            // cancel old D2D worker
+            WorkManager.getInstance(this).cancelUniqueWork("APP_BACKUP")
         }
-        // cancel old D2D worker
-        WorkManager.getInstance(this).cancelUniqueWork("APP_BACKUP")
     }
 
     private fun isFrameworkSchedulingEnabled(): Boolean = Settings.Secure.getInt(

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import android.net.NetworkRequest
 import android.net.Uri
 import android.os.BadParcelableException
 import android.os.Process.myUid
+import android.os.UserHandle
 import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
@@ -308,6 +309,8 @@ internal class SettingsViewModel(
     }
 
     fun scheduleAppBackup(existingWorkPolicy: ExistingPeriodicWorkPolicy) {
+        // disable framework scheduling, because another transport may have enabled it
+        backupManager.setFrameworkSchedulingEnabledForUser(UserHandle.myUserId(), false)
         if (!pluginManager.isOnRemovableDrive && backupManager.isBackupEnabled) {
             AppBackupWorker.schedule(app, settingsManager, existingWorkPolicy)
         }

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/BackupStorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/BackupStorageViewModel.kt
@@ -8,6 +8,7 @@ package com.stevesoltys.seedvault.ui.storage
 import android.app.Application
 import android.app.backup.IBackupManager
 import android.app.job.JobInfo
+import android.os.UserHandle
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import androidx.work.ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
@@ -100,6 +101,8 @@ internal class BackupStorageViewModel(
 
     private fun scheduleBackupWorkers() {
         val storage = storagePluginManager.storageProperties ?: error("no storage available")
+        // disable framework scheduling, because another transport may have enabled it
+        backupManager.setFrameworkSchedulingEnabledForUser(UserHandle.myUserId(), false)
         if (!storage.isUsb) {
             if (backupManager.isBackupEnabled) {
                 AppBackupWorker.schedule(app, settingsManager, CANCEL_AND_REENQUEUE)


### PR DESCRIPTION
We disable the framework scheduling in favor of our own, but there may be other transports on the system still using the framework scheduling, so we can't disable it for them and we need to account for them having enabled it again.

Fixes #679 