### PR TITLE
Improve logging relevant for WebDAV streams

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/webdav/WebDavStorage.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/webdav/WebDavStorage.kt
@@ -197,6 +197,32 @@ internal abstract class WebDavStorage(
 
         private var onClose: (() -> Unit)? = null
 
+        override fun write(b: Int) {
+            try {
+                super.write(b)
+            } catch (e: Exception) {
+                try {
+                    onClose?.invoke()
+                } catch (closeException: Exception) {
+                    e.addSuppressed(closeException)
+                }
+                throw e
+            }
+        }
+
+        override fun write(b: ByteArray?, off: Int, len: Int) {
+            try {
+                super.write(b, off, len)
+            } catch (e: Exception) {
+                try {
+                    onClose?.invoke()
+                } catch (closeException: Exception) {
+                    e.addSuppressed(closeException)
+                }
+                throw e
+            }
+        }
+
         @Throws(IOException::class)
         override fun close() {
             super.close()

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -277,6 +277,16 @@ internal class BackupCoordinator(
         return full.performFullBackup(targetPackage, fileDescriptor, flags, token, salt)
     }
 
+    /**
+     * Tells the transport to read [numBytes] bytes of data from the socket file descriptor
+     * provided in the [performFullBackup] call, and deliver those bytes to the datastore.
+     *
+     * @param numBytes The number of bytes of tarball data available to be read from the socket.
+     * @return [TRANSPORT_OK] on successful processing of the data; [TRANSPORT_ERROR] to
+     *    indicate a fatal error situation.  If an error is returned, the system will
+     *    call finishBackup() and stop attempting backups until after a backoff and retry
+     *    interval.
+     */
     suspend fun sendBackupData(numBytes: Int) = full.sendBackupData(numBytes)
 
     /**

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/FullBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/FullBackup.kt
@@ -20,7 +20,7 @@ import com.stevesoltys.seedvault.plugins.StoragePluginManager
 import com.stevesoltys.seedvault.plugins.isOutOfSpace
 import com.stevesoltys.seedvault.settings.SettingsManager
 import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
-import libcore.io.IoUtils.closeQuietly
+import java.io.Closeable
 import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream
@@ -210,9 +210,9 @@ internal class FullBackup(
         val state = this.state ?: throw AssertionError("Trying to clear empty state.")
         return try {
             state.outputStream?.flush()
-            closeQuietly(state.outputStream)
-            closeQuietly(state.inputStream)
-            closeQuietly(state.inputFileDescriptor)
+            closeLogging(state.outputStream)
+            closeLogging(state.inputStream)
+            closeLogging(state.inputFileDescriptor)
             TRANSPORT_OK
         } catch (e: IOException) {
             Log.w(TAG, "Error when clearing state", e)
@@ -220,6 +220,12 @@ internal class FullBackup(
         } finally {
             this.state = null
         }
+    }
+
+    private fun closeLogging(closable: Closeable?) = try {
+        closable?.close()
+    } catch (e: Exception) {
+        Log.w(TAG, "Error closing: ", e)
     }
 
 }


### PR DESCRIPTION
When writing to WebDAV streams, we usually only get a PipeClosed error without information what *actually* went wrong. This PR aims to improve this situation.