### PR TITLE
fragment_backup_content: Don't set custom style on FAB

### DIFF
--- a/storage/lib/src/main/res/layout/fragment_backup_content.xml
+++ b/storage/lib/src/main/res/layout/fragment_backup_content.xml
@@ -19,7 +19,6 @@
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
-        style="@style/Widget.Design.FloatingActionButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"


### PR DESCRIPTION
## Summary

Custom style conflicts with dynamic theme. Drop it.