### PR TITLE
Fix title of restore notification channel

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
@@ -81,7 +81,7 @@ internal class BackupNotificationManager(private val context: Context) {
     }
 
     private fun getRestoreChannel(): NotificationChannel {
-        val title = context.getString(R.string.notification_restore_error_channel_title)
+        val title = context.getString(R.string.notification_restore_channel_title)
         return NotificationChannel(CHANNEL_ID_RESTORE, title, IMPORTANCE_LOW)
     }
 


### PR DESCRIPTION
The restore foreground service notification uses the restore channel, which was inadvertently using the title from the error channel, showing "Auto restore flash drive error" when tapping and holding on the notification, and showing that channel name twice in the notification settings.