### PR TITLE
Also show TikTok in Backup status

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/PackageService.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/PackageService.kt
@@ -232,7 +232,11 @@ internal class PackageService(
 
 internal fun PackageInfo.isUserVisible(context: Context): Boolean {
     if (packageName == MAGIC_PACKAGE_MANAGER || applicationInfo == null) return false
-    return !isNotUpdatedSystemApp() && instrumentation == null && packageName != context.packageName
+    val isInstrumentationApp = instrumentation.let { i ->
+        // TikTok for example ships instrumentation, so do more checks. See #769
+        !i.isNullOrEmpty() && packageName.endsWith(".test") && i[0].splitNames.isEmpty()
+    }
+    return !isNotUpdatedSystemApp() && !isInstrumentationApp && packageName != context.packageName
 }
 
 internal fun PackageInfo.isSystemApp(): Boolean {


### PR DESCRIPTION
The apps ships an instrumentation configuration which we've so far only soon for instrumentation test dev apps. Now, we do more checks to identify those.

Fixes #769 