### PR TITLE
Move context SAF cross-profile hack

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -67,14 +67,7 @@ open class App : Application() {
         single { SettingsManager(this@App) }
         single { BackupNotificationManager(this@App) }
         single { BackendManager(this@App, get(), get(), get()) }
-        single {
-            BackendFactory {
-                // uses context of the device's main user to be able to access USB storage
-                this@App.applicationContext.getStorageContext {
-                    get<SettingsManager>().getSafProperties()?.isUsb == true
-                }
-            }
-        }
+        single { BackendFactory() }
         single { BackupStateManager(this@App) }
         single { Clock() }
         factory<IBackupManager> { IBackupManager.Stub.asInterface(getService(BACKUP_SERVICE)) }

--- a/app/src/main/java/com/stevesoltys/seedvault/backend/BackendManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/backend/BackendManager.kt
@@ -48,9 +48,11 @@ class BackendManager(
     init {
         when (settingsManager.storagePluginType) {
             StoragePluginType.SAF -> {
-                val safConfig = settingsManager.getSafProperties() ?: error("No SAF storage saved")
-                mBackend = backendFactory.createSafBackend(safConfig)
-                mBackendProperties = safConfig
+                val safProperties = settingsManager.getSafProperties()
+                    ?: error("No SAF storage saved")
+                val ctx = context.getStorageContext { safProperties.isUsb }
+                mBackend = backendFactory.createSafBackend(ctx, safProperties)
+                mBackendProperties = safProperties
             }
 
             StoragePluginType.WEB_DAV -> {

--- a/app/src/main/java/com/stevesoltys/seedvault/backend/saf/SafHandler.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/backend/saf/SafHandler.kt
@@ -15,6 +15,7 @@ import android.util.Log
 import androidx.annotation.WorkerThread
 import com.stevesoltys.seedvault.R
 import com.stevesoltys.seedvault.backend.BackendManager
+import com.stevesoltys.seedvault.getStorageContext
 import com.stevesoltys.seedvault.isMassStorage
 import com.stevesoltys.seedvault.settings.FlashDrive
 import com.stevesoltys.seedvault.settings.SettingsManager
@@ -58,7 +59,8 @@ internal class SafHandler(
     @WorkerThread
     @Throws(IOException::class)
     suspend fun hasAppBackup(safProperties: SafProperties): Boolean {
-        val backend = backendFactory.createSafBackend(safProperties)
+        val context = context.getStorageContext { safProperties.isUsb }
+        val backend = backendFactory.createSafBackend(context, safProperties)
         return backend.getAvailableBackupFileHandles().isNotEmpty()
     }
 
@@ -92,8 +94,9 @@ internal class SafHandler(
 
     @WorkerThread
     fun setPlugin(safProperties: SafProperties) {
+        val ctx = context.getStorageContext { safProperties.isUsb }
         backendManager.changePlugins(
-            backend = backendFactory.createSafBackend(safProperties),
+            backend = backendFactory.createSafBackend(ctx, safProperties),
             storageProperties = safProperties,
         )
     }

--- a/core/src/main/java/org/calyxos/seedvault/core/backends/BackendFactory.kt
+++ b/core/src/main/java/org/calyxos/seedvault/core/backends/BackendFactory.kt
@@ -11,11 +11,9 @@ import org.calyxos.seedvault.core.backends.saf.SafProperties
 import org.calyxos.seedvault.core.backends.webdav.WebDavBackend
 import org.calyxos.seedvault.core.backends.webdav.WebDavConfig
 
-public class BackendFactory(
-    private val contextGetter: () -> Context,
-) {
-    public fun createSafBackend(config: SafProperties): Backend =
-        SafBackend(contextGetter(), config)
+public class BackendFactory {
+    public fun createSafBackend(context: Context, config: SafProperties): Backend =
+        SafBackend(context, config)
 
     public fun createWebDavBackend(config: WebDavConfig): Backend = WebDavBackend(config)
 }


### PR DESCRIPTION
so it can be used before we save SafProperties, e.g. during restore when we need to check if backups at the given location exist.