### PR TITLE
Tell system to reinitialize when it refuses to give us data we need

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/repo/RepoModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/repo/RepoModule.kt
@@ -19,7 +19,7 @@ val repoModule = module {
         val snapshotFolder = File(androidContext().filesDir, FOLDER_SNAPSHOTS)
         SnapshotManager(snapshotFolder, get(), get(), get())
     }
-    factory { SnapshotCreatorFactory(androidContext(), get(), get(), get()) }
+    factory { SnapshotCreatorFactory(androidContext(), get(), get(), get(), get()) }
     factory { Pruner(get(), get(), get(), get()) }
     single { Checker(get(), get(), get(), get(), get(), get()) }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/repo/SnapshotCreatorFactory.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/repo/SnapshotCreatorFactory.kt
@@ -8,6 +8,7 @@ package com.stevesoltys.seedvault.repo
 import android.content.Context
 import com.stevesoltys.seedvault.Clock
 import com.stevesoltys.seedvault.metadata.MetadataManager
+import com.stevesoltys.seedvault.transport.backup.BackupInitializer
 import com.stevesoltys.seedvault.transport.backup.PackageService
 
 /**
@@ -18,7 +19,8 @@ internal class SnapshotCreatorFactory(
     private val clock: Clock,
     private val packageService: PackageService,
     private val metadataManager: MetadataManager,
+    private val backupInitializer: BackupInitializer,
 ) {
     fun createSnapshotCreator() =
-        SnapshotCreator(context, clock, packageService, metadataManager)
+        SnapshotCreator(context, clock, packageService, metadataManager, backupInitializer)
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -75,7 +75,7 @@ internal class BackupCoordinator(
     private val state = CoordinatorState(
         calledInitialize = false,
         calledClearBackupData = false,
-        cancelReason = UNKNOWN_ERROR
+        cancelReason = UNKNOWN_ERROR,
     )
     private val launchableSystemApps by lazy {
         packageService.launchableSystemApps.map { it.activityInfo.packageName }.toSet()

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupTransportMonitor.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupTransportMonitor.kt
@@ -33,11 +33,7 @@ internal class BackupTransportMonitor(
         log.info { "sendNoDataChanged($packageName)" }
 
         val snapshot = snapshotManager.latestSnapshot
-        if (snapshot == null) {
-            log.error { "No latest snapshot!" }
-        } else {
-            val snapshotCreator = appBackupManager.snapshotCreator ?: error("No SnapshotCreator")
-            snapshotCreator.onNoDataInCurrentRun(snapshot, packageName)
-        }
+        val snapshotCreator = appBackupManager.snapshotCreator ?: error("No SnapshotCreator")
+        snapshotCreator.onNoDataInCurrentRun(snapshot, packageName)
     }
 }

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCreationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCreationTest.kt
@@ -66,8 +66,13 @@ internal class BackupCreationTest : BackupTest() {
     private val backupReceiver = BackupReceiver(blobCache, blobCreator, cryptoImpl)
     private val appBackupManager = mockk<AppBackupManager>()
     private val packageService = mockk<PackageService>()
-    private val snapshotCreator =
-        SnapshotCreator(context, clock, packageService, mockk(relaxed = true))
+    private val snapshotCreator = SnapshotCreator(
+        context = context,
+        clock = clock,
+        packageService = packageService,
+        metadataManager = mockk(relaxed = true),
+        backupInitializer = mockk(relaxed = true),
+    )
     private val notificationManager = mockk<BackupNotificationManager>()
     private val db = TestKvDbManager()
 


### PR DESCRIPTION
Another hacky workaround to fix a hacky workaround.

We had talked to Google about the backup API not getting notified when essential K/V apps like `@pm@` don't have new data for backup. The only option they offered is `BackupMonitor` which gets the information at least, but out of process on another thread.

So we implemented a hacky workaround where `BackupMonitor` tells `SnapshotCreator` to extract backup data from an old snapshot.

Unfortunately, it is possible that we do a backup run which includes `@pm@`, but encounters an error later, so the system cancels the entire backup which causes us not to have `@pm@` data in a snapshots for re-use. Still, the system thinks we backed up `@pm@` and doesn't give us its data.

Closes #818 