### PR TITLE
Try everything to abort backups on metered network (when not allowed)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,6 +161,14 @@
         </receiver>
 
         <receiver
+            android:name=".settings.TryAgainBroadcastReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.stevesoltys.seedvault.action.TRY_AGAIN" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
             android:name=".restore.RestoreErrorBroadcastReceiver"
             android:exported="false">
             <intent-filter>

--- a/app/src/main/java/com/stevesoltys/seedvault/backend/BackendManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/backend/BackendManager.kt
@@ -110,7 +110,7 @@ class BackendManager(
      * @return true if a backup is possible, false if not.
      */
     @WorkerThread
-    fun canDoBackupNow(): Boolean {
+    override fun canDoBackupNow(): Boolean {
         val storage = backendProperties ?: return false
         return !isOnUnavailableUsb() &&
             !storage.isUnavailableNetwork(context, settingsManager.useMeteredNetwork)

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
@@ -200,6 +200,17 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private fun onMenuItemSelected(item: MenuItem): Boolean = when (item.itemId) {
         R.id.action_backup -> {
             viewModel.backupNow()
+            if (!backendManager.canDoBackupNow()) {
+                // if USB isn't plugged in, this action shouldn't be enabled,
+                // so this leaves only that we are on a metered network
+                MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(getString(R.string.settings_backup_metered_title))
+                    .setMessage(getString(R.string.settings_backup_metered_text))
+                    .setNeutralButton(getString(R.string.restore_storage_got_it)) { dialog, _ ->
+                        dialog.dismiss()
+                    }
+                    .show()
+            }
             true
         }
         R.id.action_restore -> {

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/TryAgainBroadcastReceiver.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/TryAgainBroadcastReceiver.kt
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2020 The Calyx Institute
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.stevesoltys.seedvault.settings
+
+import android.app.backup.IBackupManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.stevesoltys.seedvault.backend.BackendManager
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
+import com.stevesoltys.seedvault.worker.BackupRequester.Companion.requestFilesAndAppBackup
+import org.koin.core.context.GlobalContext.get
+
+internal const val ACTION_TRY_AGAIN = "com.stevesoltys.seedvault.action.TRY_AGAIN"
+
+class TryAgainBroadcastReceiver : BroadcastReceiver() {
+
+    // using KoinComponent would crash robolectric tests :(
+    private val notificationManager: BackupNotificationManager by lazy { get().get() }
+    private val backendManager: BackendManager by lazy { get().get() }
+    private val settingsManager: SettingsManager by lazy { get().get() }
+    private val backupManager: IBackupManager by lazy { get().get() }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_TRY_AGAIN) return
+
+        notificationManager.onBackupErrorSeen()
+
+        val reschedule = !backendManager.isOnRemovableDrive
+        requestFilesAndAppBackup(context, settingsManager, backupManager, reschedule)
+    }
+
+}

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -204,6 +204,10 @@ internal class BackupCoordinator(
         flags: Int,
     ): Int {
         state.cancelReason = UNKNOWN_ERROR
+        if (!backendManager.canDoBackupNow()) {
+            Log.w(TAG, "performIncrementalBackup(): Can't do backup now, rejecting...")
+            return TRANSPORT_PACKAGE_REJECTED
+        }
         return kv.performBackup(packageInfo, data, flags)
     }
 
@@ -229,6 +233,10 @@ internal class BackupCoordinator(
     }
 
     fun checkFullBackupSize(size: Long): Int {
+        if (!backendManager.canDoBackupNow()) {
+            Log.w(TAG, "checkFullBackupSize(): Can't do backup now, rejecting...")
+            return TRANSPORT_PACKAGE_REJECTED
+        }
         val result = full.checkFullBackupSize(size)
         if (result == TRANSPORT_PACKAGE_REJECTED) state.cancelReason = NO_DATA
         else if (result == TRANSPORT_QUOTA_EXCEEDED) state.cancelReason = QUOTA_EXCEEDED
@@ -241,6 +249,10 @@ internal class BackupCoordinator(
         flags: Int,
     ): Int {
         state.cancelReason = UNKNOWN_ERROR
+        if (!backendManager.canDoBackupNow()) {
+            Log.w(TAG, "performFullBackup(): Can't do backup now, rejecting...")
+            return TRANSPORT_PACKAGE_REJECTED
+        }
         return full.performFullBackup(targetPackage, fileDescriptor, flags)
     }
 

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/AppBackupWorker.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/AppBackupWorker.kt
@@ -132,8 +132,10 @@ class AppBackupWorker(
                     return Result.failure()
                 }
                 val result = doBackup()
-                // show error notification if backup wasn't successful (maybe only when no retry?)
-                if (result != Result.success()) nm.onBackupError()
+                // show error notification if backup wasn't successful
+                if (result != Result.success()) {
+                    nm.onBackupError(meteredNetwork = !backendManager.canDoBackupNow())
+                }
                 // only allow retrying if rescheduling is allowed
                 if (tags.contains(TAG_RESCHEDULE)) return result
                 else Result.success()

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/BackupRequester.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/BackupRequester.kt
@@ -70,12 +70,10 @@ internal class BackupRequester(
 
     val isBackupEnabled: Boolean get() = backupManager.isBackupEnabled
 
-    private val packages = packageService.eligiblePackages
-    private val observer = NotificationBackupObserver(
-        context = context,
-        backupRequester = this,
-        requestedPackages = packages.size,
-    )
+    private val packages by lazy { packageService.eligiblePackages }
+    private val observer by lazy {
+        NotificationBackupObserver(context, this, packages.size)
+    }
 
     /**
      * The current package index.

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/BackupRequester.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/BackupRequester.kt
@@ -92,6 +92,11 @@ internal class BackupRequester(
     }
 
     /**
+     * Returns true, if there are more packages waiting to get backed up by calling [requestNext].
+     */
+    val hasNext: Boolean get() = packageIndex < packages.size
+
+    /**
      * Backs up the next chunk of packages.
      *
      * @return true, if backup for all packages was already requested and false,

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/WorkerModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/WorkerModule.kt
@@ -40,6 +40,7 @@ val workerModule = module {
         ApkBackupManager(
             context = androidContext(),
             appBackupManager = get(),
+            backendManager = get(),
             settingsManager = get(),
             snapshotManager = get(),
             metadataManager = get(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,8 +60,8 @@
     <string name="settings_backup_new_code_dialog_title">New recovery code required</string>
     <string name="settings_backup_new_code_dialog_message">To continue using app backups, you need to generate a new recovery code.\n\nWe are sorry for the inconvenience.</string>
     <string name="settings_backup_new_code_code_dialog_ok">New code</string>
-    <string name="settings_backup_metered_title">Metered network</string>
-    <string name="settings_backup_metered_text">You are currently on a network where you may pay for data, so backup won\'t proceed.\n\nYou can enable backups on mobile data under \"Backup scheduling\".</string>
+    <string name="settings_backup_metered_title">Backup stopped</string>
+    <string name="settings_backup_metered_text">The backup won\'t proceed because your device is using mobile data.\n\nYou can enable backups on mobile data under \"Backup scheduling\".</string>
 
 
     <string name="settings_scheduling_frequency_title">Backup frequency</string>
@@ -172,7 +172,7 @@
     <string name="notification_success_text">%1$d of %2$d apps backed up (%3$s). Tap to learn more.</string>
     <string name="notification_failed_title">Backup failed</string>
     <string name="notification_failed_text">An error occurred while running the backup.</string>
-    <string name="notification_failed_metered_text">Device had switched to metered network, so backup was aborted.</string>
+    <string name="notification_failed_metered_text">The backup has been aborted. Are you using mobile data? Connect to Wi-Fi to continue.</string>
 
     <string name="notification_error_channel_title">Error notification</string>
     <string name="notification_error_title">Backup error</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,9 @@
     <string name="settings_backup_new_code_dialog_title">New recovery code required</string>
     <string name="settings_backup_new_code_dialog_message">To continue using app backups, you need to generate a new recovery code.\n\nWe are sorry for the inconvenience.</string>
     <string name="settings_backup_new_code_code_dialog_ok">New code</string>
+    <string name="settings_backup_metered_title">Metered network</string>
+    <string name="settings_backup_metered_text">You are currently on a network where you may pay for data, so backup won\'t proceed.\n\nYou can enable backups on mobile data under \"Backup scheduling\".</string>
+
 
     <string name="settings_scheduling_frequency_title">Backup frequency</string>
     <string name="settings_scheduling_frequency_12_hours">Every 12 hours</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,7 @@
     <string name="notification_success_text">%1$d of %2$d apps backed up (%3$s). Tap to learn more.</string>
     <string name="notification_failed_title">Backup failed</string>
     <string name="notification_failed_text">An error occurred while running the backup.</string>
+    <string name="notification_failed_metered_text">Device had switched to metered network, so backup was aborted.</string>
 
     <string name="notification_error_channel_title">Error notification</string>
     <string name="notification_error_title">Backup error</string>

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
@@ -138,6 +138,7 @@ internal class CoordinatorIntegrationTest : TransportTest() {
 
     init {
         every { backendManager.backend } returns backend
+        every { backendManager.canDoBackupNow() } returns true
         every { appBackupManager.snapshotCreator } returns snapshotCreator
     }
 

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCreationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/BackupCreationTest.kt
@@ -98,6 +98,7 @@ internal class BackupCreationTest : BackupTest() {
 
     init {
         every { backendManager.backend } returns backend
+        every { backendManager.canDoBackupNow() } returns true
         every { appBackupManager.snapshotCreator } returns snapshotCreator
         every { clock.time() } returns token
         every { packageInfo.applicationInfo?.loadLabel(any()) } returns packageName

--- a/app/src/test/java/com/stevesoltys/seedvault/worker/ApkBackupManagerTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/worker/ApkBackupManagerTest.kt
@@ -30,8 +30,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
 import kotlinx.coroutines.runBlocking
-import org.calyxos.seedvault.core.backends.Backend
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class ApkBackupManagerTest : TransportTest() {
 
@@ -41,12 +41,12 @@ internal class ApkBackupManagerTest : TransportTest() {
     private val apkBackup: ApkBackup = mockk()
     private val iconManager: IconManager = mockk()
     private val backendManager: BackendManager = mockk()
-    private val backend: Backend = mockk()
     private val nm: BackupNotificationManager = mockk()
 
     private val apkBackupManager = ApkBackupManager(
         context = context,
         appBackupManager = appBackupManager,
+        backendManager = backendManager,
         settingsManager = settingsManager,
         snapshotManager = snapshotManager,
         metadataManager = metadataManager,
@@ -60,7 +60,6 @@ internal class ApkBackupManagerTest : TransportTest() {
     private val snapshotCreator: SnapshotCreator = mockk()
 
     init {
-        every { backendManager.backend } returns backend
         every { appBackupManager.snapshotCreator } returns snapshotCreator
     }
 
@@ -213,6 +212,7 @@ internal class ApkBackupManagerTest : TransportTest() {
             nm.onApkBackup(notAllowedPackages[0].packageName, any(), 0, notAllowedPackages.size)
         } just Runs
         every { snapshotManager.latestSnapshot } returns snapshot
+        every { backendManager.canDoBackupNow() } returns true
         // no backup needed
         coEvery { apkBackup.backupApkIfNecessary(notAllowedPackages[0], snapshot) } just Runs
         // update notification for second package
@@ -230,6 +230,23 @@ internal class ApkBackupManagerTest : TransportTest() {
             apkBackup.backupApkIfNecessary(notAllowedPackages[0], snapshot)
             apkBackup.backupApkIfNecessary(notAllowedPackages[1], snapshot)
         }
+    }
+
+    @Test
+    fun `backup gets aborted when we can't do backup right now`() = runBlocking {
+        val packages = listOf(
+            PackageInfo().apply { packageName = "org.example.1" },
+        )
+
+        expectUploadIcons()
+        expectAllAppsWillGetBackedUp()
+        every { settingsManager.backupApks() } returns true
+        every { packageService.allUserPackages } returns packages
+        every { backendManager.canDoBackupNow() } returns false
+        every { nm.onApkBackupDone() } just Runs
+
+        assertThrows<IllegalStateException> { apkBackupManager.backup() }
+        Unit
     }
 
     @Test

--- a/core/src/main/java/org/calyxos/seedvault/core/backends/IBackendManager.kt
+++ b/core/src/main/java/org/calyxos/seedvault/core/backends/IBackendManager.kt
@@ -9,6 +9,7 @@ public interface IBackendManager {
     public val backend: Backend
     public val isOnRemovableDrive: Boolean
     public val requiresNetwork: Boolean
+    public fun canDoBackupNow(): Boolean
 }
 
 public enum class BackendId {

--- a/core/src/main/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackend.kt
+++ b/core/src/main/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackend.kt
@@ -43,6 +43,7 @@ import org.calyxos.seedvault.core.backends.TopLevelFolder
 import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.concurrent.TimeUnit
@@ -351,7 +352,7 @@ public class WebDavBackend(
     }
 
     override fun isTransientException(e: Exception): Boolean {
-        if (e is SocketTimeoutException) {
+        if (e is SocketTimeoutException || e is SocketException) {
             return true
         } else if (e is UnknownHostException) {
             return true // gets thrown when phone leaves WiFi range

--- a/storage/demo/src/main/java/de/grobox/storagebackuptester/App.kt
+++ b/storage/demo/src/main/java/de/grobox/storagebackuptester/App.kt
@@ -25,6 +25,7 @@ class App : Application() {
         override val backend: Backend get() = plugin
         override val isOnRemovableDrive: Boolean = false
         override val requiresNetwork: Boolean = false
+        override fun canDoBackupNow(): Boolean = true
     }
     val settingsManager: SettingsManager by lazy { SettingsManager(applicationContext) }
     val storageBackup: StorageBackup by lazy {

--- a/storage/lib/src/main/java/org/calyxos/backup/storage/backup/ChunkWriter.kt
+++ b/storage/lib/src/main/java/org/calyxos/backup/storage/backup/ChunkWriter.kt
@@ -50,10 +50,12 @@ internal class ChunkWriter(
         inputStream: InputStream,
         chunks: List<Chunk>,
         missingChunkIds: List<String>,
+        wasAborted: () -> Boolean,
     ): ChunkWriterResult {
         var writtenChunks = 0
         var writtenBytes = 0L
         chunks.forEach { chunk ->
+            if (wasAborted()) throw IOException("Metered Network")
             val cachedChunk = chunksCache.get(chunk.id)
             // TODO missing chunks used by several files will get uploaded several times
             val isMissing = chunk.id in missingChunkIds

--- a/storage/lib/src/main/java/org/calyxos/backup/storage/backup/FileBackup.kt
+++ b/storage/lib/src/main/java/org/calyxos/backup/storage/backup/FileBackup.kt
@@ -34,6 +34,7 @@ internal class FileBackup(
     suspend fun backupFiles(
         files: List<ContentFile>,
         availableChunkIds: Set<String>,
+        wasAborted: () -> Boolean,
         backupObserver: BackupObserver?,
     ): BackupResult {
         val chunkIds = HashSet<String>()
@@ -41,6 +42,7 @@ internal class FileBackup(
         val backupDocumentFiles = ArrayList<BackupDocumentFile>()
         var bytesWritten = 0L
         files.forEach { file ->
+            if (wasAborted()) throw IOException("Metered Network")
             val result = try {
                 backupFile(file, availableChunkIds)
             } catch (e: IOException) {

--- a/storage/lib/src/main/java/org/calyxos/backup/storage/backup/SmallFileBackup.kt
+++ b/storage/lib/src/main/java/org/calyxos/backup/storage/backup/SmallFileBackup.kt
@@ -33,6 +33,7 @@ internal class SmallFileBackup(
     suspend fun backupFiles(
         files: List<ContentFile>,
         availableChunkIds: Set<String>,
+        wasAborted: () -> Boolean,
         backupObserver: BackupObserver?,
     ): BackupResult {
         val chunkIds = HashSet<String>()
@@ -66,6 +67,7 @@ internal class SmallFileBackup(
             } else true
         }
         changedFiles.windowed(2, 1, true).forEach { window ->
+            if (wasAborted()) throw IOException("Metered Network")
             val file = window[0]
             val result = try {
                 makeZipChunk(window, missingChunkIds)

--- a/storage/lib/src/test/java/org/calyxos/backup/storage/BackupRestoreTest.kt
+++ b/storage/lib/src/test/java/org/calyxos/backup/storage/BackupRestoreTest.kt
@@ -92,6 +92,7 @@ internal class BackupRestoreTest {
         mockkStatic("org.calyxos.backup.storage.UriUtilsKt")
 
         every { backendManager.backend } returns backend
+        every { backendManager.canDoBackupNow() } returns true
         every { db.getFilesCache() } returns filesCache
         every { db.getChunksCache() } returns chunksCache
         every { keyManager.getMainKey() } returns SecretKeySpec(
@@ -526,6 +527,7 @@ internal class BackupRestoreTest {
             keyManager = keyManager,
             cacheRepopulater = cacheRepopulater,
         )
+        every { backendManagerNew.canDoBackupNow() } returns true
         every { backendManagerNew.backend } returnsMany listOf(backend1, backend2)
 
         coEvery { backend1.list(any(), Blob::class, callback = any()) } just Runs

--- a/storage/lib/src/test/java/org/calyxos/backup/storage/backup/SmallFileBackupIntegrationTest.kt
+++ b/storage/lib/src/test/java/org/calyxos/backup/storage/backup/SmallFileBackupIntegrationTest.kt
@@ -121,7 +121,7 @@ internal class SmallFileBackupIntegrationTest {
             observer.onFileBackedUp(file2, true, 0, match<Long> { it <= outputStream2.size() }, "S")
         } just Runs
 
-        val result = smallFileBackup.backupFiles(files, availableChunkIds, observer)
+        val result = smallFileBackup.backupFiles(files, availableChunkIds, { false }, observer)
         assertEquals(setOf(chunkId.toHexString()), result.chunkIds)
         assertEquals(1, result.backupDocumentFiles.size)
         assertEquals(backupFile, result.backupDocumentFiles[0])


### PR DESCRIPTION
This does several improvements to not cause traffic while user is on mobile data:

* Halt app backup worker progress
* Improve app backup error notification: add try again button and language when error was due to metered network
* stops apk backup
* show error dialog when manually requesting backup
* stop app backups
* stop file backups

This also treats `SocketException` as transient.

Fixes #794