### PR TITLE
strings: use APK wording instead of app

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,12 +28,12 @@
     <string name="settings_auto_restore_summary">When reinstalling an app, restore backed up settings and data.</string>
     <string name="settings_auto_restore_summary_usb">Note: Your %1$s needs to be plugged in for this to work.</string>
     <string name="settings_category_app_data_backup">App data backup</string>
-    <string name="settings_backup_apk_title">App backup</string>
-    <string name="settings_backup_apk_summary">Back up the apps themselves. Otherwise, only app data would get backed up.</string>
-    <string name="settings_backup_apk_dialog_title">Really disable app backup?</string>
-    <string name="settings_backup_apk_dialog_message">Disabled app backup will still back up app data. However, it will not get restored automatically.\n\nYou will need to install all your apps manually while having \"Automatic Restore\" switched on.</string>
+    <string name="settings_backup_apk_title">APK backups</string>
+    <string name="settings_backup_apk_summary">Backs up the apps themselves. Otherwise, only app data will get backed up.</string>
+    <string name="settings_backup_apk_dialog_title">Really disable APK backups?</string>
+    <string name="settings_backup_apk_dialog_message">After disabling APK backups, app data will still be backed up. However, it will not get restored automatically.\n\nYou will need to install all your apps manually while having \"Automatic Restore\" switched on.</string>
     <string name="settings_backup_apk_dialog_cancel">Cancel</string>
-    <string name="settings_backup_apk_dialog_disable">Disable app backup</string>
+    <string name="settings_backup_apk_dialog_disable">Disable APK backups</string>
     <string name="settings_backup_status_title">Backup status</string>
     <string name="settings_backup_status_summary">Last backup: %1$s</string>
     <string name="settings_backup_status_next_backup">Next backup: %1$s</string>


### PR DESCRIPTION
This setting is now in expert settings, maybe we can be more specific?