### PR TITLE
Fix a few issues with strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
     <string name="storage_fake_drive_summary">Needs to be plugged in</string>
     <string name="storage_available_bytes"><xliff:g example="1 GB" id="size">%1$s</xliff:g> free</string>
     <string name="storage_not_recommended"><xliff:g example="Skynet">%1$s</xliff:g> (Not recommended)</string>
-    <string name="storage_round_sync_summary_prefix" translatable="false">RoundSync Remote: </string>
+    <string name="storage_round_sync_summary_prefix">RoundSync Remote: </string>
     <string name="storage_fake_nextcloud_title" translatable="false">Nextcloud</string>
     <string name="storage_fake_nextcloud_summary">Tap to install</string>
     <string name="storage_fake_nextcloud_summary_installed">Tap to set up account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,7 +281,7 @@
     <string name="restore_finished_button">Finish</string>
 
     <string name="restore_storage_skip">Skip restoring files</string>
-    <string name="restore_storage_choose_snapshot">Choose a storage backup to restore (beta)</string>
+    <string name="restore_storage_choose_snapshot">Choose a file backup to restore (beta)</string>
     <string name="restore_storage_selection_description">Selected files will be restored. Tap folders to see files in them.</string>
     <string name="restore_storage_in_progress_title">Files are being restored…</string>
     <string name="restore_storage_in_progress_info">Your files are being restored in the background. You can start using your phone while this is running.\n\nSome apps (e.g. Signal or WhatsApp) might require files to be fully restored to import a backup. Try to avoid starting those apps before file restore is complete.</string>

--- a/storage/lib/src/main/res/values/strings.xml
+++ b/storage/lib/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="notification_backup_scanning">Scanning files…</string>
     <string name="notification_backup_backup_files">Backing up files…</string>
     <string name="notification_prune">Removing old backups…</string>
-    <string name="notification_restore_channel_title">Storage restore</string>
+    <string name="notification_restore_channel_title">File backup restore</string>
     <string name="notification_restore_title">Restoring files…</string>
     <string name="notification_restore_info">%1$d/%2$d</string>
     <string name="notification_restore_complete_title">%1$d of %2$d files restored</string>
@@ -30,8 +30,8 @@
     <string name="notification_check_error_text">Tap for details. We checked %1$s at an average speed of %2$s.</string>
     <string name="notification_check_action">Details</string>
 
-    <string name="snapshots_title">Available storage backups</string>
-    <string name="snapshots_empty">No storage backups found\n\nSorry, but there is nothing that can be restored.</string>
+    <string name="snapshots_title">Available file backups</string>
+    <string name="snapshots_empty">No file backups found\n\nSorry, but there is nothing that can be restored.</string>
     <string name="snapshots_error">Error loading snapshots</string>
 
     <string name="select_files_title">Review files for restore</string>

--- a/storage/lib/src/main/res/values/strings.xml
+++ b/storage/lib/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="notification_prune">Removing old backups…</string>
     <string name="notification_restore_channel_title">File backup restore</string>
     <string name="notification_restore_title">Restoring files…</string>
-    <string name="notification_restore_info">%1$d/%2$d</string>
+    <string name="notification_restore_info" translatable="false">%1$d/%2$d</string>
     <string name="notification_restore_complete_title">%1$d of %2$d files restored</string>
     <string name="notification_restore_complete_dups">%1$d files were duplicates.</string>
     <string name="notification_restore_complete_errors">%1$d files had errors.</string>
@@ -39,7 +39,7 @@
     <string name="select_files_button_restore">Restore selected files</string>
 
     <string name="check_success_intro">%1$d snapshots were found and %2$d%% of their data (%3$s) successfully verified:</string>
-    <string name="check_error_title">@string/notification_check_error_title</string>
+    <string name="check_error_title" translatable="false">@string/notification_check_error_title</string>
     <string name="check_error_no_snapshots">We could not find any backup. Please run a successful backup first and then try checking again.</string>
     <string name="check_error_only_broken_snapshots">We found %1$d backup snapshots. However, all of them were corrupted. Please run a successful backup and then try checking again.</string>
     <string name="check_error_has_snapshots">We found %1$d backup snapshots, some of them are corrupted or have errors. Below are the backups that can (partly) be restored.</string>


### PR DESCRIPTION
* Be consistent in using "file backup" instead of "storage backup" (following 41f47620e4044be6b3e5eed58f3c237e4c9e7cf6)
* Fix a few strings to be marked (or not anymore) as not translatable