### PR TITLE
strings: nit: file restore

### DIFF
--- a/storage/lib/src/main/res/values/strings.xml
+++ b/storage/lib/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="notification_backup_scanning">Scanning files…</string>
     <string name="notification_backup_backup_files">Backing up files…</string>
     <string name="notification_prune">Removing old backups…</string>
-    <string name="notification_restore_channel_title">File backup restore</string>
+    <string name="notification_restore_channel_title">File restore</string>
     <string name="notification_restore_title">Restoring files…</string>
     <string name="notification_restore_info" translatable="false">%1$d/%2$d</string>
     <string name="notification_restore_complete_title">%1$d of %2$d files restored</string>


### PR DESCRIPTION
File restore seems better than "File backup restore" which I used in #873 and probably saves space for translators