### PR TITLE
eng builds are debug too

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -193,7 +193,7 @@ const val ERROR_BACKUP_CANCELLED: Int = BackupManager.ERROR_BACKUP_CANCELLED
 const val ERROR_BACKUP_NOT_ALLOWED: Int = BackupManager.ERROR_BACKUP_NOT_ALLOWED
 
 // TODO this doesn't work for LineageOS as they do public debug builds
-fun isDebugBuild() = Build.TYPE == "userdebug"
+fun isDebugBuild() = Build.TYPE == "userdebug" || Build.TYPE == "eng"
 
 fun <T> permitDiskReads(func: () -> T): T {
     return if (isDebugBuild()) {


### PR DESCRIPTION
I've been running -eng builds for additional debugging lately and noticed that I couldn't screenshot + needed to write down the recovery code.