### PR TITLE
Simplify debug build check logic

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -193,7 +193,7 @@ const val ERROR_BACKUP_CANCELLED: Int = BackupManager.ERROR_BACKUP_CANCELLED
 const val ERROR_BACKUP_NOT_ALLOWED: Int = BackupManager.ERROR_BACKUP_NOT_ALLOWED
 
 // TODO this doesn't work for LineageOS as they do public debug builds
-fun isDebugBuild() = Build.TYPE == "userdebug" || Build.TYPE == "eng"
+fun isDebugBuild() = Build.TYPE != "user"
 
 fun <T> permitDiskReads(func: () -> T): T {
     return if (isDebugBuild()) {


### PR DESCRIPTION
Since there only one non-debugging build variant, i think it's better to keep it simple