### PR TITLE
Launch a foreground service when finalizing backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -187,6 +187,12 @@
             android:exported="false"
             android:label="BackupJobService"
             android:permission="android.permission.BIND_JOB_SERVICE" />
+        <!-- Does app backup finalization as a foreground service -->
+        <service
+            android:name=".transport.backup.FinalizeBackupService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            android:label="FinalizeBackupService" />
         <!-- Does app restore as a foreground service -->
         <service
             android:name=".restore.RestoreService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,7 @@
 
     <!-- Used for periodic storage backups -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <!-- Permission used to open settings -->
     <permission
@@ -191,8 +192,11 @@
         <service
             android:name=".transport.backup.FinalizeBackupService"
             android:exported="false"
-            android:foregroundServiceType="dataSync"
-            android:label="FinalizeBackupService" />
+            android:foregroundServiceType="specialUse"
+            android:label="FinalizeBackupService">
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Look, finalizing the backup is super important. We had the system kill our dataSync service, so what else should we do?"/>
+        </service>
         <!-- Does app restore as a foreground service -->
         <service
             android:name=".restore.RestoreService"

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/FinalizeBackupService.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/FinalizeBackupService.kt
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2024 The Calyx Institute
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.stevesoltys.seedvault.transport.backup
+
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
+import android.os.IBinder
+import android.util.Log
+import com.stevesoltys.seedvault.R
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
+import com.stevesoltys.seedvault.ui.notification.NOTIFICATION_ID_OBSERVER
+import org.koin.android.ext.android.inject
+
+class FinalizeBackupService : Service() {
+
+    companion object {
+        private const val TAG = "FinalizeBackupService"
+    }
+
+    private val nm: BackupNotificationManager by inject()
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(TAG, "onStartCommand $intent $flags $startId")
+
+        val str = applicationContext.getString(R.string.notification_finalizing_text)
+        startForeground(
+            NOTIFICATION_ID_OBSERVER,
+            nm.getBackupNotification(str),
+            FOREGROUND_SERVICE_TYPE_MANIFEST,
+        )
+        return START_STICKY_COMPATIBILITY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onDestroy() {
+        Log.i(TAG, "onDestroy")
+        nm.cancelBackupNotification()
+        super.onDestroy()
+    }
+
+}

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
@@ -138,7 +138,7 @@ internal class BackupNotificationManager(private val context: Context) {
     /**
      * Call after [onApkBackup] or [onAppsNotBackedUp] were called.
      */
-    fun onApkBackupDone() {
+    fun cancelBackupNotification() {
         nm.cancel(NOTIFICATION_ID_OBSERVER)
     }
 

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/NotificationBackupObserver.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/NotificationBackupObserver.kt
@@ -9,6 +9,7 @@ import android.app.backup.BackupProgress
 import android.app.backup.BackupTransport.AGENT_ERROR
 import android.app.backup.IBackupObserver
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ApplicationInfo.FLAG_SYSTEM
 import android.content.pm.PackageManager.NameNotFoundException
 import android.os.Looper
@@ -25,6 +26,7 @@ import com.stevesoltys.seedvault.metadata.PackageState.NOT_ALLOWED
 import com.stevesoltys.seedvault.repo.AppBackupManager
 import com.stevesoltys.seedvault.repo.hexFromProto
 import com.stevesoltys.seedvault.settings.SettingsManager
+import com.stevesoltys.seedvault.transport.backup.FinalizeBackupService
 import com.stevesoltys.seedvault.transport.backup.PackageService
 import com.stevesoltys.seedvault.worker.AppBackupPruneWorker
 import com.stevesoltys.seedvault.worker.BackupRequester
@@ -115,7 +117,7 @@ internal class NotificationBackupObserver(
             // this should only ever happen for system apps, as we use only d2d now
             if (target in launchableSystemApps) {
                 val packageInfo = context.packageManager.getPackageInfo(target, 0)
-                 metadataManager.onPackageBackupError(packageInfo, NOT_ALLOWED)
+                metadataManager.onPackageBackupError(packageInfo, NOT_ALLOWED)
             }
         }
 
@@ -161,32 +163,23 @@ internal class NotificationBackupObserver(
             //  since the rest of packages from the failed chunk won't get backed up.
             //  So we either re-include those packages somehow (may fail again in a loop!)
             //  or we simply fail the entire backup which may cause more failures for users :(
-            var success = status == 0
-            val total = try {
-                packageService.allUserPackages.size
-            } catch (e: Exception) {
-                Log.e(TAG, "Error getting number of all user packages: ", e)
-                requestedPackages
-            }
-            val snapshot = runBlocking {
-                check(!Looper.getMainLooper().isCurrentThread)
-                Log.d(TAG, "Finalizing backup...")
-                val snapshot = appBackupManager.afterBackupFinished(success)
-                success = snapshot != null
-                snapshot
-            }
-            val size = if (snapshot != null) { // TODO for later: count size of APKs separately
-                val chunkIds = snapshot.appsMap.values.flatMap { it.chunkIdsList }
-                chunkIds.sumOf {
-                    snapshot.blobsMap[it.hexFromProto()]?.uncompressedLength?.toLong() ?: 0L
+            val success = status == 0
+            val i = Intent(context, FinalizeBackupService::class.java)
+            try {
+                // Starting a foreground service, because the system may freeze/kill us otherwise
+                // before we are done here, because the TransportService gets destroyed now
+                // and the wakelock the system holds for us gets released. See #866 for more info.
+                context.startService(i)
+                // finalize backup only when success is true
+                val error = !success || !finalizeBackup()
+                if (error) {
+                    runBlocking {
+                        appBackupManager.afterBackupFinished(false)
+                    }
+                    nm.onBackupError()
                 }
-            } else 0L
-            if (success) {
-                nm.onBackupSuccess(numPackagesToReport, total, size)
-                // prune old backups
-                AppBackupPruneWorker.scheduleNow(context)
-            } else {
-                nm.onBackupError()
+            } finally {
+                context.stopService(i)
             }
         }
     }
@@ -207,6 +200,38 @@ internal class NotificationBackupObserver(
         }
         Log.i(TAG, "$numPackages/$requestedPackages - $appName ($packageName)")
         nm.onBackupUpdate(name, numPackages, requestedPackages)
+    }
+
+    /**
+     * Returns true, if finalizing was successful.
+     */
+    private fun finalizeBackup(): Boolean {
+        // finalize and save snapshot
+        val snapshot = runBlocking {
+            check(!Looper.getMainLooper().isCurrentThread) // off UiThread
+            Log.d(TAG, "Finalizing backup...")
+            appBackupManager.afterBackupFinished(true)
+        }
+        // abort on error
+        if (snapshot == null) return false
+
+        // get info about backup
+        val total = try {
+            packageService.allUserPackages.size
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting number of all user packages: ", e)
+            requestedPackages
+        }
+        val size = snapshot.appsMap.values.flatMap {
+            it.chunkIdsList // TODO for later: count size of APKs separately
+        }.sumOf {
+            snapshot.blobsMap[it.hexFromProto()]?.uncompressedLength?.toLong() ?: 0L
+        }
+        // show notification
+        nm.onBackupSuccess(numPackagesToReport, total, size)
+        // prune old backups
+        AppBackupPruneWorker.scheduleNow(context)
+        return true
     }
 
     private fun getAppName(packageId: String): CharSequence = getAppName(context, packageId)

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/ApkBackupManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/ApkBackupManager.kt
@@ -53,7 +53,7 @@ internal class ApkBackupManager(
                 backUpApks()
             }
         } finally {
-            nm.onApkBackupDone()
+            nm.cancelBackupNotification()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="notification_success_channel_title">Success notification</string>
     <string name="notification_title">Backup running</string>
     <string name="notification_init_text">Preparing existing backup data for reuse…</string>
+    <string name="notification_finalizing_text">Finalizing backup…</string>
     <string name="notification_apk_text">Backing up APK of %s</string>
     <string name="notification_apk_not_backed_up">Saving list of apps we can not back up.</string>
     <string name="notification_backup_already_running">Backup already in progress</string>

--- a/app/src/test/java/com/stevesoltys/seedvault/worker/ApkBackupManagerTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/worker/ApkBackupManagerTest.kt
@@ -81,7 +81,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         every { metadataManager.onPackageDoesNotGetBackedUp(packageInfo, NOT_ALLOWED) } just Runs
 
         every { settingsManager.backupApks() } returns false
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         apkBackupManager.backup()
 
@@ -107,7 +107,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         every { metadataManager.onPackageDoesNotGetBackedUp(packageInfo, NOT_ALLOWED) } just Runs
 
         every { settingsManager.backupApks() } returns false
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         apkBackupManager.backup()
 
@@ -141,7 +141,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         every { metadataManager.onPackageDoesNotGetBackedUp(packageInfo, WAS_STOPPED) } just Runs
 
         every { settingsManager.backupApks() } returns false
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         apkBackupManager.backup()
 
@@ -167,7 +167,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         every { packageMetadata.state } returns NOT_ALLOWED
 
         every { settingsManager.backupApks() } returns false
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         apkBackupManager.backup()
 
@@ -186,7 +186,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         expectUploadIcons()
 
         every { settingsManager.backupApks() } returns false
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         apkBackupManager.backup()
 
@@ -227,7 +227,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         // was backed up, get new packageMetadata
         coEvery { apkBackup.backupApkIfNecessary(notAllowedPackages[1], snapshot) } just Runs
 
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         apkBackupManager.backup()
 
@@ -248,7 +248,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         every { settingsManager.backupApks() } returns true
         every { packageService.allUserPackages } returns packages
         every { backendManager.canDoBackupNow() } returns false
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         assertThrows<IllegalStateException> { apkBackupManager.backup() }
         Unit
@@ -265,7 +265,7 @@ internal class ApkBackupManagerTest : TransportTest() {
         every { settingsManager.backupApks() } returns true
         every { packageService.allUserPackages } returns packages
         every { backendManager.canDoBackupNow() } returns true andThen false
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         assertThrows<IllegalStateException> { apkBackupManager.backup() }
         Unit
@@ -290,7 +290,7 @@ internal class ApkBackupManagerTest : TransportTest() {
 
         every { settingsManager.backupApks() } returns false
 
-        every { nm.onApkBackupDone() } just Runs
+        every { nm.cancelBackupNotification() } just Runs
 
         apkBackupManager.backup()
 


### PR DESCRIPTION
This is to prevent the system from freezing/killing us while we are still finalizing.

There has been a bit of refactoring around finalizing backups, so it would be nice to test backup errors and backups to slow network storage. Only when a backup succeeds, we should see a notification saying "Finalizing backup...".

Closes #866 