### PR TITLE
Don't request backup more than once when we are notified about available USB storage

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/UsbMonitorService.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/UsbMonitorService.kt
@@ -20,6 +20,7 @@ import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import com.stevesoltys.seedvault.ui.notification.NOTIFICATION_ID_USB_MONITOR
 import com.stevesoltys.seedvault.worker.BackupRequester.Companion.requestFilesAndAppBackup
 import org.koin.android.ext.android.inject
+import java.util.concurrent.atomic.AtomicBoolean
 
 private const val TAG = "UsbMonitorService"
 
@@ -39,12 +40,18 @@ class UsbMonitorService : Service() {
         val rootsUri = intent.data ?: error("No URI in start intent.")
         val contentResolver = contentResolver
         val handler = Handler(Looper.myLooper() ?: error("no looper"))
+        val hasRequestedBackup = AtomicBoolean(false)
         val observer = object : ContentObserver(handler) {
             override fun onChange(selfChange: Boolean, uri: Uri?) {
                 super.onChange(selfChange, uri)
                 Log.i(TAG, "onChange() requesting backup now!")
                 contentResolver.unregisterContentObserver(this)
-                requestFilesAndAppBackup(applicationContext, settingsManager, backupManager)
+                // The [ContentObserver] may notify us here more than once,
+                // so we check if we have already requested the backup.
+                // [getAndSet] returns the old value, so we check if that is still false
+                if (!hasRequestedBackup.getAndSet(true)) {
+                    requestFilesAndAppBackup(applicationContext, settingsManager, backupManager)
+                }
                 Log.i(TAG, "stopSelf($startId)")
                 stopSelf(startId)
             }

--- a/app/src/main/java/com/stevesoltys/seedvault/worker/BackupRequester.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/worker/BackupRequester.kt
@@ -12,7 +12,10 @@ import android.os.RemoteException
 import android.util.Log
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
+import androidx.work.WorkInfo.State.RUNNING
+import androidx.work.WorkManager
 import com.stevesoltys.seedvault.settings.SettingsManager
+import com.stevesoltys.seedvault.transport.ConfigurableBackupTransportService
 import com.stevesoltys.seedvault.transport.backup.BackupTransportMonitor
 import com.stevesoltys.seedvault.transport.backup.PackageService
 import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
@@ -47,6 +50,12 @@ internal class BackupRequester(
             backupManager: IBackupManager,
             reschedule: Boolean = false,
         ) {
+            // Extra protection against running more than one backup at a time.
+            // This may happen for example when entering a flash drive multiple times.
+            if (isBackupRunning(context)) {
+                Log.e(TAG, "Backup already running, not requesting again.")
+                return
+            }
             if (settingsManager.isFileBackupEnabled()) {
                 // This launches file backup first,
                 // because the app backup worker only kicks off the backup and finishes early.
@@ -57,6 +66,29 @@ internal class BackupRequester(
                 AppBackupWorker.scheduleNow(context)
             } else {
                 Log.d(TAG, "Neither files nor app backup enabled, do nothing.")
+            }
+        }
+
+        fun isBackupRunning(context: Context): Boolean {
+            val workManager = WorkManager.getInstance(context)
+            val appBackupRunning = ConfigurableBackupTransportService.isRunning.value
+            return try {
+                val appBackupState = workManager
+                    .getWorkInfosForUniqueWork(AppBackupWorker.UNIQUE_WORK_NAME).get()
+                    .getOrNull(0)?.state
+                val fileBackupState = workManager
+                    .getWorkInfosForUniqueWork(AppBackupWorker.UNIQUE_WORK_NAME).get()
+                    .getOrNull(0)?.state
+                Log.i(
+                    TAG, "appBackupRunning: $appBackupRunning, " +
+                        "filesBackupRunning: ${fileBackupState?.name}, " +
+                        "appBackupWorker: ${appBackupState?.name}"
+                )
+                appBackupRunning || fileBackupState == RUNNING || appBackupState == RUNNING
+            } catch (e: Exception) {
+                Log.e(TAG, "Error determining current backup state: ", e)
+                // not much we can do here, let's just assume no backup is running
+                false
             }
         }
     }


### PR DESCRIPTION
Test instructions:
* set up backup to usb
* eject drive
* fake system time or code
* insert drive
* observe/save logcat and system notification that it actually starts a new backup

You'll see `UsbIntentReceiver` logging `Last backup older than it should be, requesting a backup...` or `We have a recent backup, not requesting a new one.`.

You can't really test that this fixes the multiple start issue, but what is important is that it still does backups at all ;)

Starting a backup manually would also be nice to test.

Extra hard test scenario: Insert and remove and re-insert flashdrive short after. Ideally, we can detect that it had already requested a backup and won't request a second one.

May close #923