### PR TITLE
Add ScrollView to restore screens for small screen support

### DIFF
--- a/app/src/main/res/layout/fragment_recycle_backup.xml
+++ b/app/src/main/res/layout/fragment_recycle_backup.xml
@@ -2,67 +2,73 @@
   SPDX-FileCopyrightText: 2024 The Calyx Institute
   SPDX-License-Identifier: Apache-2.0
   -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <ImageView
-        android:id="@+id/imageView"
-        style="@style/SudHeaderIcon"
-        android:importantForAccessibility="no"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_cloud_reuse"
-        app:tint="?android:colorAccent" />
-
-    <TextView
-        android:id="@+id/titleView"
-        style="@style/SudHeaderTitle"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/restore_recycle_backup_title"
-        android:textColor="?android:textColorSecondary"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/imageView" />
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/descriptionView"
-        style="@style/SudContent"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="@string/restore_recycle_backup_text"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/titleView" />
+        <ImageView
+            android:id="@+id/imageView"
+            style="@style/SudHeaderIcon"
+            android:importantForAccessibility="no"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_cloud_reuse"
+            app:tint="?android:colorAccent" />
 
-    <Button
-        android:id="@+id/noButton"
-        style="@style/SudSecondaryButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="40dp"
-        android:text="@string/restore_recycle_backup_button_no"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/yesButton"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/descriptionView"
-        app:layout_constraintVertical_bias="1.0" />
+        <TextView
+            android:id="@+id/titleView"
+            style="@style/SudHeaderTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/restore_recycle_backup_title"
+            android:textColor="?android:textColorSecondary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/imageView" />
 
-    <Button
-        android:id="@+id/yesButton"
-        style="@style/SudPrimaryButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="40dp"
-        android:text="@string/restore_recycle_backup_button_yes"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/descriptionView"
-        app:layout_constraintVertical_bias="1.0" />
+        <TextView
+            android:id="@+id/descriptionView"
+            style="@style/SudContent"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/restore_recycle_backup_text"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/titleView" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <Button
+            android:id="@+id/noButton"
+            style="@style/SudSecondaryButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="40dp"
+            android:text="@string/restore_recycle_backup_button_no"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/yesButton"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/descriptionView"
+            app:layout_constraintVertical_bias="1.0" />
+
+        <Button
+            android:id="@+id/yesButton"
+            style="@style/SudPrimaryButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="40dp"
+            android:text="@string/restore_recycle_backup_button_yes"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/descriptionView"
+            app:layout_constraintVertical_bias="1.0" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_restore_files_started.xml
+++ b/app/src/main/res/layout/fragment_restore_files_started.xml
@@ -3,51 +3,57 @@
   SPDX-FileCopyrightText: 2020 The Calyx Institute
   SPDX-License-Identifier: Apache-2.0
   -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <ImageView
-        android:id="@+id/imageView"
-        style="@style/SudHeaderIcon"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_cloud_restore"
-        app:tint="?android:colorAccent"
-        tools:ignore="ContentDescription" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/titleView"
-        style="@style/SudHeaderTitle"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="@string/restore_storage_in_progress_title"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/imageView" />
+        <ImageView
+            android:id="@+id/imageView"
+            style="@style/SudHeaderIcon"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_cloud_restore"
+            app:tint="?android:colorAccent"
+            tools:ignore="ContentDescription" />
 
-    <TextView
-        android:id="@+id/infoView"
-        style="@style/SudContent"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="@string/restore_storage_in_progress_info"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/titleView" />
+        <TextView
+            android:id="@+id/titleView"
+            style="@style/SudHeaderTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/restore_storage_in_progress_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/imageView" />
 
-    <Button
-        android:id="@+id/button"
-        style="@style/SudPrimaryButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="40dp"
-        android:text="@string/restore_storage_got_it"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/infoView"
-        app:layout_constraintVertical_bias="1.0" />
+        <TextView
+            android:id="@+id/infoView"
+            style="@style/SudContent"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/restore_storage_in_progress_info"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/titleView" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <Button
+            android:id="@+id/button"
+            style="@style/SudPrimaryButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="40dp"
+            android:text="@string/restore_storage_got_it"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/infoView"
+            app:layout_constraintVertical_bias="1.0" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
Fix layout overflow on small screen devices (tested on Doov R77) where the restore screens were cut off and not scrollable.

- Wrap `ConstraintLayout` in `ScrollView` with `fillViewport="true"` for:
  - `fragment_recycle_backup.xml` (the "Reuse this backup?" screen)
  - `fragment_restore_files_started.xml` (the "File restore in progress" screen)

This follows the same pattern already used in other layouts like `fragment_recovery_code_input.xml`. The `fillViewport` attribute keeps buttons anchored at the bottom on larger screens while allowing content to scroll on smaller ones.