### PR TITLE
docs: add Seednaut utility to third-party tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,17 +87,17 @@ Seedvault can be translated with Weblate, as provided by [CalyxOS](https://hoste
 > The Seedvault developers make no guarantees about external software projects.
 > Please be aware that disclosing your secret recovery key to other software has security risks.
 
-The [Seedvault backup parser](https://github.com/tlambertz/seedvault_backup_parser)
-allows you to decrypt and inspect your backups (version 0 backup).
-It can also re-encrypt them.
+The [Seednaut](https://github.com/Baltram/seednaut) utility
+allows you to decrypt and inspect your backups (version 2 backup).
+It also supports file backups.
 
 The [Seedvault extractor](https://github.com/jackwilsdon/seedvault-extractor)
-allows you to decrypt and inspect your backups (version 1 backup).
+allows you to decrypt and inspect your backups from older versions of Seedvault (version 1 backup).
 It is currently work-in-progress.
 
-The [Seednaut](https://github.com/Baltram/seednaut) utility
-allows you to decrypt and inspect your backups from newer versions of Seedvault (version 2 backup).
-It also supports file backups (version 0).
+The [Seedvault backup parser](https://github.com/tlambertz/seedvault_backup_parser)
+allows you to decrypt and inspect your backups from older versions of Seedvault (version 0 backup).
+It can also re-encrypt them.
 
 ## License
 This application is available as open source under the terms

--- a/README.md
+++ b/README.md
@@ -92,8 +92,12 @@ allows you to decrypt and inspect your backups (version 0 backup).
 It can also re-encrypt them.
 
 The [Seedvault extractor](https://github.com/jackwilsdon/seedvault-extractor)
-allows you to decrypt and inspect your backups from newer versions of Seedvault (version 1 backup).
+allows you to decrypt and inspect your backups (version 1 backup).
 It is currently work-in-progress.
+
+The [Seednaut](https://github.com/Baltram/seednaut) utility
+allows you to decrypt and inspect your backups from newer versions of Seedvault (version 2 backup).
+It also supports file backups (version 0).
 
 ## License
 This application is available as open source under the terms


### PR DESCRIPTION
Hi! I recently released Seednaut, an open-source CLI utility for inspecting/extracting Seedvault backups.

It supports current v2 app backups as well as v0 file backups.

Since the README already lists third-party tooling for older backup formats, I thought it could be useful to include Seednaut as an option for users working with current backups too.

Happy to adjust the wording if preferred.